### PR TITLE
remove redundant xmltodict in _decrypt_message

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import, unicode_literals
 import unittest
 
+import xmltodict
+
 from wechatpy.enterprise import crypto as _crypto
 from wechatpy.enterprise.crypto import WeChatCrypto
 
@@ -88,5 +90,6 @@ class CryptoTestCase(unittest.TestCase):
 
         crypto = WeChatCrypto(self.token, self.encoding_aes_key, self.corp_id)
         msg = crypto.decrypt_message(xml, signature, timestamp, nonce)
-        self.assertEqual('test', msg['Content'])
-        self.assertEqual('messense', msg['FromUserName'])
+        msg_dict = xmltodict.parse(msg)['xml']
+        self.assertEqual('test', msg_dict['Content'])
+        self.assertEqual('messense', msg_dict['FromUserName'])

--- a/wechatpy/crypto.py
+++ b/wechatpy/crypto.py
@@ -159,9 +159,7 @@ class BaseWeChatCrypto(object):
         if _signature != signature:
             raise InvalidSignatureException()
         pc = crypto_class(self.key)
-        xml = pc.decrypt(encrypt, self._id)
-        message = xmltodict.parse(to_text(xml))['xml']
-        return message
+        return pc.decrypt(encrypt, self._id)
 
 
 class WeChatCrypto(BaseWeChatCrypto):

--- a/wechatpy/enterprise/parser.py
+++ b/wechatpy/enterprise/parser.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, unicode_literals
-import six
+import xmltodict
 
 from .messages import MESSAGE_TYPES
 from .events import EVENT_TYPES
@@ -7,11 +7,10 @@ from ..messages import UnknownMessage
 from ..utils import to_text
 
 
-def parse_message(message):
-    if isinstance(message, six.string_types):
-        import xmltodict
-
-        message = xmltodict.parse(to_text(message))['xml']
+def parse_message(xml):
+    if not xml:
+        return
+    message = xmltodict.parse(to_text(xml))['xml']
     message_type = message['MsgType'].lower()
     if message_type == 'event':
         event_type = message['Event'].lower()


### PR DESCRIPTION
if the returned message is used in parse_message, it should be a string, instead of a dict

enterprise.crypto works because its parser accepted different type of parameter, which is a surprise for caller.
