### PR TITLE
Refactor client

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,6 +44,15 @@ class WeChatClientTestCase(unittest.TestCase):
     def setUp(self):
         self.client = WeChatClient(self.app_id, self.secret)
 
+    def test_two_client_not_equal(self):
+        client2 = WeChatClient('654321', '654321', '987654321')
+        assert self.client != client2
+        assert self.client.user != client2.user
+        assert id(self.client.menu) != id(client2.menu)
+        with HTTMock(wechat_api_mock):
+            self.client.fetch_access_token()
+            assert self.client.access_token != client2.access_token
+
     def test_fetch_access_token(self):
         with HTTMock(wechat_api_mock):
             token = self.client.fetch_access_token()

--- a/wechatpy/client/__init__.py
+++ b/wechatpy/client/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
-import weakref
 
 from wechatpy.client.base import BaseWeChatClient
 from wechatpy.client import api
@@ -14,32 +13,28 @@ class WeChatClient(BaseWeChatClient):
 
     API_BASE_URL = 'https://api.weixin.qq.com/cgi-bin/'
 
+    menu = api.WeChatMenu()
+    user = api.WeChatUser()
+    group = api.WeChatGroup()
+    media = api.WeChatMedia()
+    card = api.WeChatCard()
+    qrcode = api.WeChatQRCode()
+    message = api.WeChatMessage()
+    misc = api.WeChatMisc()
+    merchant = api.WeChatMerchant()
+    customservice = api.WeChatCustomService()
+    datacube = api.WeChatDataCube()
+    jsapi = api.WeChatJSAPI()
+    material = api.WeChatMaterial()
+    semantic = api.WeChatSemantic()
+    shakearound = api.WeChatShakeAround()
+    device = api.WeChatDevice()
+    template = api.WeChatTemplate()
+
     def __init__(self, appid, secret, access_token=None):
+        super(WeChatClient, self).__init__(access_token)
         self.appid = appid
         self.secret = secret
-        self._access_token = access_token
-        self.expires_at = None
-
-        weak_self = weakref.proxy(self)
-
-        # APIs
-        self.menu = api.WeChatMenu(weak_self)
-        self.user = api.WeChatUser(weak_self)
-        self.group = api.WeChatGroup(weak_self)
-        self.media = api.WeChatMedia(weak_self)
-        self.card = api.WeChatCard(weak_self)
-        self.qrcode = api.WeChatQRCode(weak_self)
-        self.message = api.WeChatMessage(weak_self)
-        self.misc = api.WeChatMisc(weak_self)
-        self.merchant = api.WeChatMerchant(weak_self)
-        self.customservice = api.WeChatCustomService(weak_self)
-        self.datacube = api.WeChatDataCube(weak_self)
-        self.jsapi = api.WeChatJSAPI(weak_self)
-        self.material = api.WeChatMaterial(weak_self)
-        self.semantic = api.WeChatSemantic(weak_self)
-        self.shakearound = api.WeChatShakeAround(weak_self)
-        self.device = api.WeChatDevice(weak_self)
-        self.template = api.WeChatTemplate(weak_self)
 
     def fetch_access_token(self):
         """

--- a/wechatpy/client/api/base.py
+++ b/wechatpy/client/api/base.py
@@ -2,15 +2,18 @@
 from __future__ import absolute_import, unicode_literals
 
 
+class APIDescriptor(object):
+
+    def __init__(self, api):
+        self.api = api
+
+    def __get__(self, instance, instance_type=None):
+        return self.api
+
+
 class BaseWeChatAPI(object):
     """ WeChat API base class """
-
-    def __init__(self, client):
-        """
-        Init with WeChatClient object
-
-        :param client: An instance of WeChatClient
-        """
+    def __init__(self, client=None):
         self._client = client
 
     def _get(self, url, **kwargs):
@@ -26,3 +29,6 @@ class BaseWeChatAPI(object):
     @property
     def access_token(self):
         return self._client.access_token
+
+    def add_to_class(self, klass, name):
+        klass._api_endpoints[name] = self

--- a/wechatpy/client/api/base.py
+++ b/wechatpy/client/api/base.py
@@ -1,18 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
-import weakref
-
-
-class APIDescriptor(object):
-
-    def __init__(self, api):
-        self.api = api
-
-    def __get__(self, instance, instance_type=None):
-        if instance is not None:
-            if self.api._client is None:
-                self.api._client = weakref.proxy(instance)
-        return self.api
 
 
 class BaseWeChatAPI(object):
@@ -33,7 +20,3 @@ class BaseWeChatAPI(object):
     @property
     def access_token(self):
         return self._client.access_token
-
-    def add_to_class(self, klass, name):
-        klass._api_endpoints[name] = self
-        setattr(klass, name, APIDescriptor(self))

--- a/wechatpy/client/api/base.py
+++ b/wechatpy/client/api/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+import weakref
 
 
 class APIDescriptor(object):
@@ -8,6 +9,9 @@ class APIDescriptor(object):
         self.api = api
 
     def __get__(self, instance, instance_type=None):
+        if instance is not None:
+            if self.api._client is None:
+                self.api._client = weakref.proxy(instance)
         return self.api
 
 
@@ -32,3 +36,4 @@ class BaseWeChatAPI(object):
 
     def add_to_class(self, klass, name):
         klass._api_endpoints[name] = self
+        setattr(klass, name, APIDescriptor(self))

--- a/wechatpy/client/api/base.py
+++ b/wechatpy/client/api/base.py
@@ -10,12 +10,12 @@ class BaseWeChatAPI(object):
     def _get(self, url, **kwargs):
         if getattr(self, 'API_BASE_URL', None):
             kwargs['api_base_url'] = self.API_BASE_URL
-        return self._client._get(url, **kwargs)
+        return self._client.get(url, **kwargs)
 
     def _post(self, url, **kwargs):
         if getattr(self, 'API_BASE_URL', None):
             kwargs['api_base_url'] = self.API_BASE_URL
-        return self._client._post(url, **kwargs)
+        return self._client.post(url, **kwargs)
 
     @property
     def access_token(self):

--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -82,19 +82,23 @@ class BaseWeChatClient(object):
 
         return result
 
-    def _get(self, url, **kwargs):
+    def get(self, url, **kwargs):
         return self._request(
             method='get',
             url_or_endpoint=url,
             **kwargs
         )
 
-    def _post(self, url, **kwargs):
+    _get = get
+
+    def post(self, url, **kwargs):
         return self._request(
             method='post',
             url_or_endpoint=url,
             **kwargs
         )
+
+    _post = post
 
     def _fetch_access_token(self, url, params):
         """ The real fetch access token """

--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 import time
 import copy
-import weakref
 
 import six
 import requests
@@ -23,7 +22,7 @@ class _ClientMetaClass(type):
                 if k in attrs:
                     continue
                 if isinstance(v, APIDescriptor):
-                    attrs[k] = copy.deepcopy(v.api)
+                    attrs[k] = copy.deepcopy(v)
 
         cls = super(_ClientMetaClass, cls).__new__(cls, name, bases, attrs)
         cls._api_endpoints = {}
@@ -41,13 +40,6 @@ class BaseWeChatClient(six.with_metaclass(_ClientMetaClass)):
     def __init__(self, access_token=None):
         self._access_token = access_token
         self.expires_at = None
-
-        weak_self = weakref.proxy(self)
-        for name, api in self._api_endpoints.items():
-            if not isinstance(api, BaseWeChatAPI):
-                continue
-            api._client = weak_self
-            setattr(self, name, api)
 
     def _request(self, method, url_or_endpoint, **kwargs):
         if not url_or_endpoint.startswith(('http://', 'https://')):

--- a/wechatpy/enterprise/client/__init__.py
+++ b/wechatpy/enterprise/client/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
-import weakref
 
 from wechatpy.client.base import BaseWeChatClient
 from wechatpy.enterprise.client import api
@@ -10,23 +9,21 @@ class WeChatClient(BaseWeChatClient):
 
     API_BASE_URL = 'https://qyapi.weixin.qq.com/cgi-bin/'
 
+    user = api.WeChatUser()
+    department = api.WeChatDepartment()
+    menu = api.WeChatMenu()
+    message = api.WeChatMessage()
+    tag = api.WeChatTag()
+    media = api.WeChatMedia()
+    misc = api.WeChatMisc()
+    agent = api.WeChatAgent()
+    batch = api.WeChatBatch()
+
     def __init__(self, corp_id, secret, access_token=None):
         self.corp_id = corp_id
         self.secret = secret
         self._access_token = access_token
         self.expires_at = None
-
-        weak_self = weakref.proxy(self)
-        # APIs
-        self.user = api.WeChatUser(weak_self)
-        self.department = api.WeChatDepartment(weak_self)
-        self.menu = api.WeChatMenu(weak_self)
-        self.message = api.WeChatMessage(weak_self)
-        self.tag = api.WeChatTag(weak_self)
-        self.media = api.WeChatMedia(weak_self)
-        self.misc = api.WeChatMisc(weak_self)
-        self.agent = api.WeChatAgent(weak_self)
-        self.batch = api.WeChatBatch(weak_self)
 
     def fetch_access_token(self):
         """ Fetch access token"""


### PR DESCRIPTION
主动调用接口 `WeChatClient` API 实现重构。
## Changes
- 代码层面 API Endpoint 从实例属性变为类属性，在实例化后依然会和对应的实例绑定。此更改对库使用者而言是透明的。
- `WeChatClient` 原有的 `_get` 和 `_post` 更名 `get` 和 `post`，以前的接口依然保留。对于 `wechatpy` 没有实现的接口，可以使用 `get` 和 `post` 自行实现。
