### PR TITLE
get component_verify_ticket from external cache.

### DIFF
--- a/wechatpy/component.py
+++ b/wechatpy/component.py
@@ -27,7 +27,6 @@ class BaseWeChatComponent(object):
     def __init__(self,
                  component_appid,
                  component_appsecret,
-                 component_verify_ticket,
                  session=None):
         """
         :param component_appid: 第三方平台appid
@@ -49,8 +48,6 @@ class BaseWeChatComponent(object):
             shove = Shove(session)
             storage = ShoveStorage(shove, prefix)
             self.session = storage
-        self.session.set(
-            'component_verify_ticket', component_verify_ticket, 600)
 
     @property
     def component_verify_ticket(self):
@@ -319,7 +316,9 @@ class WeChatComponent(BaseWeChatComponent):
         refresh_token = result['authorization_info']['authorizer_refresh_token']
         authorizer_appid = result['authorization_info']['authorizer_appid']  # noqa
         return WeChatComponentClient(
-            authorizer_appid, access_token, refresh_token, self)
+            authorizer_appid, access_token, refresh_token, self,
+            session=self.session
+        )
 
     def get_client(
             self,
@@ -343,5 +342,6 @@ class WeChatComponent(BaseWeChatComponent):
             authorizer_appid,
             authorizer_access_token,
             authorizer_refresh_token,
-            self
+            self,
+            session=self.session
         )


### PR DESCRIPTION
1. component_verify_ticket的更新发生在WeChatComponent外部，WeChatComponent的实例只能获取；2. component_verify_ticket的更新 和 component_verify_ticket的使用多半发生在不同进程间，所以 session 变成必须的。
2. 开放平台中公众号的 access_token更新只能通过component进行；为了保证 refresh_token 的有效，必然需要外部代码更新已经授权的所有公众号，这也要求外部代码和component，component和公众号能访问到更新后的refresh_token，而 component.session可以做到。
