### PR TITLE
在调用语义分析接口出错的时候，微信有时不会返回errmsg字段

### DIFF
--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -138,7 +138,7 @@ class BaseWeChatClient(object):
 
         if 'errcode' in result and result['errcode'] != 0:
             errcode = result['errcode']
-            errmsg = result['errmsg']
+            errmsg = result.get('errmsg', errcode)
             if errcode in (40001, 40014, 42001):
                 # access_token expired, fetch a new one and retry request
                 self.fetch_access_token()


### PR DESCRIPTION
Hi，首先谢谢你提供了这个功能非常完备的微信python包！

我在调用微信提醒相关的语义分析接口时，发现微信在出错时并不总会返回errmsg字段，比如分析`闹钟`这个`query`时，返回的就是

``` javascript
{
  'query': '闹钟', 
  'errcode': 20703
}
```
