### PR TITLE
oauth authorize_url 参数错误

### DIFF
--- a/wechatpy/enterprise/client/api/oauth.py
+++ b/wechatpy/enterprise/client/api/oauth.py
@@ -19,7 +19,7 @@ class WeChatOAuth(BaseWeChatAPI):
         :param state: 重定向后会带上 state 参数
         :return: 返回的 JSON 数据包
         """
-        redirect_uri = six.moves.urllib.parse.quote(self.redirect_uri)
+        redirect_uri = six.moves.urllib.parse.quote(redirect_uri)
         url_list = [
             self.OAUTH_BASE_URl,
             '?appid=',


### PR DESCRIPTION
redirect_uri = six.moves.urllib.parse.quote(self.redirect_ui)
应该改为：
redirect_uri = six.moves.urllib.parse.quote(redirect_uri)
