### PR TITLE
Fix Bug: format_url error when some params' value is empty.

### DIFF
--- a/wechatpy/pay/utils.py
+++ b/wechatpy/pay/utils.py
@@ -9,7 +9,7 @@ from wechatpy.utils import to_binary, to_text
 
 
 def format_url(params, api_key=None):
-    data = [to_binary('{0}={1}'.format(k, params[k])) for k in sorted(params)]
+    data = [to_binary('{0}={1}'.format(k, params[k])) for k in sorted(params) if params[k]]
     if api_key:
         data.append(to_binary('key={0}'.format(api_key)))
     return b"&".join(data)


### PR DESCRIPTION
Refer Official Doc: https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=4_3

```
第一步，设所有发送或者接收到的数据为集合M，将集合M内非空参数值的参数按照参数名ASCII码从小到大排序（字典序），使用URL键值对的格式（即key1=value1&key2=value2…）拼接成字符串stringA。
特别注意以下重要规则：
◆ 参数名ASCII码从小到大排序（字典序）；
◆ 如果参数的值为空不参与签名；
◆ 参数名区分大小写；
◆ 验证调用返回或微信主动通知签名时，传送的sign参数不参与签名，将生成的签名与该sign值作校验。
◆ 微信接口可能增加字段，验证签名时必须支持增加的扩展字段
```

In function format_url, this important ruler is lost.

```
◆ 如果参数的值为空不参与签名；
```
