### PR TITLE
add check_signature for WeChatPay

### DIFF
--- a/wechatpy/pay/__init__.py
+++ b/wechatpy/pay/__init__.py
@@ -10,8 +10,9 @@ from optionaldict import optionaldict
 
 from wechatpy.utils import random_string
 from wechatpy.exceptions import WeChatPayException
-from wechatpy.pay.utils import calculate_signature
-from wechatpy.pay.utils import dict_to_xml
+from wechatpy.pay.utils import (
+    calculate_signature, _check_signature, dict_to_xml
+)
 from wechatpy.pay.base import BaseWeChatPayAPI
 from wechatpy.pay import api
 
@@ -159,3 +160,6 @@ class WeChatPay(object):
             url_or_endpoint=url,
             **kwargs
         )
+
+    def check_signature(self, params):
+        return _check_signature(params, self.api_key)

--- a/wechatpy/pay/utils.py
+++ b/wechatpy/pay/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+import copy
 import hashlib
 import socket
 
@@ -18,6 +19,12 @@ def format_url(params, api_key=None):
 def calculate_signature(params, api_key):
     url = format_url(params, api_key)
     return to_text(hashlib.md5(url).hexdigest().upper())
+
+
+def _check_signature(params, api_key):
+    _params = copy.deepcopy(params)
+    sign = _params.pop('sign', '')
+    return sign == calculate_signature(_params, api_key)
 
 
 def dict_to_xml(d, sign):


### PR DESCRIPTION
## check signature

Wechat Office Docs support developer check signature after get params from wechat server's callback.
- See:  [https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_7&index=3](https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_7&index=3)
  
  ```
  特别提醒：商户系统对于支付结果通知的内容一定要做签名验证，防止数据泄漏导致出现“假通知”，造成资金损失。
  ```
## Usage

```
  wxpay = WeChatPay(wechat.get('appID'), wechat.get('apiKey'), wechat.get('mchID'))

  wxpay.check_signature(params)  # True for success, False for fail
```
