### PR TITLE
add auto retry option

### DIFF
--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -45,6 +45,7 @@ class BaseWeChatClient(object):
         self.expires_at = None
         self.session = session or MemoryStorage()
         self.timeout = timeout
+        self.auto_retry = True
 
         if isinstance(session, six.string_types):
             from shove import Shove
@@ -138,7 +139,7 @@ class BaseWeChatClient(object):
         if 'errcode' in result and result['errcode'] != 0:
             errcode = result['errcode']
             errmsg = result.get('errmsg', errcode)
-            if errcode in (40001, 40014, 42001):
+            if errcode in (40001, 40014, 42001) and self.auto_retry:
                 # access_token expired, fetch a new one and retry request
                 self.fetch_access_token()
                 access_token = self.session.get(self.access_token_key)


### PR DESCRIPTION
Hi，我现在遇到了一个问题。我们的 access_token 是集中管理的，我改了 WeChatClient 的 get_weixin_access_token 的实现，现在通过内部服务来获取 access_token。
但当服务故障的时候可能返回错误的 access_token，现在 wechatpy 的实现会无限重试导致程序卡死挂掉，所以希望能支持关闭这种自动重试。当服务故障时，能接受 wechatpy 报错，但不能接受因为死循环导致连带着 webserver 一起挂掉。
