### PR TITLE
fix json decode

### DIFF
--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -113,7 +113,7 @@ class BaseWeChatClient(object):
     def _decode_result(self, res):
         res.encoding = 'utf-8'
         try:
-            result = res.json()
+            result = json.loads(res.content.decode('utf-8', errors='ignore'))
         except (TypeError, ValueError):
             # Return origin response object if we can not decode it as JSON
             return res


### PR DESCRIPTION
我这边有一个用户资料是这样的 `{"subscribe":1,"openid":"*","nickname":"monk","sex":1,"language":"zh_CN","city":"Y'Qt","province":"SN¬","country":"","headimgurl":"http:\/\/wx.qlogo.cn\/mmopen\/ajNVdqHZLLBGnfR2C0W8cSLBbkeQASsMaSQsOKPwL9vIGr1Zen9zj9Jwibt06kpicNvH1NU7uWFZQ8rG4CrPD7uA\/0","subscribe_time":1376237570,"unionid":"*","remark":"","groupid":0,"tagid_list":[]}`

其中 province 字段最后一个字符的 unicode 是 172 ，无法正常 decode，需要加 strict 参数。

![image](https://cloud.githubusercontent.com/assets/3659110/15703878/4eed858c-281a-11e6-883e-d42b3447c6e9.png)

代码中其他地方也可能有这种问题。
