### PR TITLE
Merchant update pr

### DIFF
--- a/wechatpy/client/api/merchant/group.py
+++ b/wechatpy/client/api/merchant/group.py
@@ -9,7 +9,7 @@ class MerchantGroup(BaseWeChatAPI):
         return self._post(
             'merchant/group/add',
             data={
-                'groups_detail': {
+                'group_detail': {
                     'group_name': name,
                     'product_list': product_list
                 }
@@ -55,6 +55,6 @@ class MerchantGroup(BaseWeChatAPI):
             data={
                 'group_id': group_id
             },
-            result_processor=lambda x: x['groups_detail']
+            result_processor=lambda x: x['group_detail']
         )
         return res

--- a/wechatpy/client/api/merchant/group.py
+++ b/wechatpy/client/api/merchant/group.py
@@ -9,7 +9,7 @@ class MerchantGroup(BaseWeChatAPI):
         return self._post(
             'merchant/group/add',
             data={
-                'group_detail': {
+                'groups_detail': {
                     'group_name': name,
                     'product_list': product_list
                 }
@@ -45,7 +45,7 @@ class MerchantGroup(BaseWeChatAPI):
     def get_all(self):
         res = self._get(
             'merchant/group/getall',
-            result_processor=lambda x: x['group_detail']
+            result_processor=lambda x: x['groups_detail']
         )
         return res
 
@@ -55,6 +55,6 @@ class MerchantGroup(BaseWeChatAPI):
             data={
                 'group_id': group_id
             },
-            result_processor=lambda x: x['group_detail']
+            result_processor=lambda x: x['groups_detail']
         )
         return res

--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -83,6 +83,10 @@ class BaseWeChatClient(object):
         if url.startswith('https://file.api.weixin.qq.com'):
             kwargs['verify'] = False
 
+        # 微信小店API手册v1.16中将所有请求url改成了https://api.weixin.qq.com/merchant/XXXXX形式
+        if url_or_endpoint.startswith('merchant/'):
+            url = 'https://api.weixin.qq.com/{endpoint}'.format(endpoint=url_or_endpoint)
+
         if 'params' not in kwargs:
             kwargs['params'] = {}
         if isinstance(kwargs['params'], dict) and \


### PR DESCRIPTION
1.微信小店API手册v1.16中将所有请求url改成了如下形式：

> https://api.weixin.qq.com/merchant/XXXXX

遂新增一条判断，将merchant相关的url进行了替换
2.微信小店中的获取所有分组API返回数据的关键字目前已经变成了'groups_detail'，我在group.py中进行了替换