### PR TITLE
更新微信小店中的请求url和获取所有分组API的关键字

### DIFF
--- a/wechatpy/client/api/merchant/__init__.py
+++ b/wechatpy/client/api/merchant/__init__.py
@@ -13,6 +13,8 @@ from wechatpy.client.api.merchant.common import MerchantCommon
 
 class WeChatMerchant(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+
     def __init__(self, *args, **kwargs):
         super(WeChatMerchant, self).__init__(*args, **kwargs)
 

--- a/wechatpy/client/api/merchant/category.py
+++ b/wechatpy/client/api/merchant/category.py
@@ -5,6 +5,8 @@ from wechatpy.client.api.base import BaseWeChatAPI
 
 class MerchantCategory(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+    
     def get_sub_categories(self, cate_id):
         res = self._post(
             'merchant/category/getsub',

--- a/wechatpy/client/api/merchant/category.py
+++ b/wechatpy/client/api/merchant/category.py
@@ -6,7 +6,7 @@ from wechatpy.client.api.base import BaseWeChatAPI
 class MerchantCategory(BaseWeChatAPI):
 
     API_BASE_URL = 'https://api.weixin.qq.com/'
-    
+
     def get_sub_categories(self, cate_id):
         res = self._post(
             'merchant/category/getsub',

--- a/wechatpy/client/api/merchant/common.py
+++ b/wechatpy/client/api/merchant/common.py
@@ -5,6 +5,8 @@ from wechatpy.client.api.base import BaseWeChatAPI
 
 class MerchantCommon(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+
     def upload_image(self, filename, image_data):
         res = self._post(
             'merchant/common/upload_img',

--- a/wechatpy/client/api/merchant/express.py
+++ b/wechatpy/client/api/merchant/express.py
@@ -5,6 +5,8 @@ from wechatpy.client.api.base import BaseWeChatAPI
 
 class MerchantExpress(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+
     def add(self, delivery_template):
         return self._post(
             'merchant/express/add',

--- a/wechatpy/client/api/merchant/group.py
+++ b/wechatpy/client/api/merchant/group.py
@@ -5,6 +5,8 @@ from wechatpy.client.api.base import BaseWeChatAPI
 
 class MerchantGroup(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+
     def add(self, name, product_list):
         return self._post(
             'merchant/group/add',

--- a/wechatpy/client/api/merchant/group.py
+++ b/wechatpy/client/api/merchant/group.py
@@ -45,7 +45,7 @@ class MerchantGroup(BaseWeChatAPI):
     def get_all(self):
         res = self._get(
             'merchant/group/getall',
-            result_processor=lambda x: x['group_detail']
+            result_processor=lambda x: x['groups_detail']
         )
         return res
 

--- a/wechatpy/client/api/merchant/order.py
+++ b/wechatpy/client/api/merchant/order.py
@@ -6,6 +6,8 @@ from wechatpy.client.api.base import BaseWeChatAPI
 
 class MerchantOrder(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+
     def get(self, order_id):
         res = self._post(
             'merchant/order/getbyid',

--- a/wechatpy/client/api/merchant/shelf.py
+++ b/wechatpy/client/api/merchant/shelf.py
@@ -5,6 +5,8 @@ from wechatpy.client.api.base import BaseWeChatAPI
 
 class MerchantShelf(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+
     def add(self, name, banner, shelf_data):
         return self._post(
             'merchant/shelf/add',

--- a/wechatpy/client/api/merchant/stock.py
+++ b/wechatpy/client/api/merchant/stock.py
@@ -5,6 +5,8 @@ from wechatpy.client.api.base import BaseWeChatAPI
 
 class MerchantStock(BaseWeChatAPI):
 
+    API_BASE_URL = 'https://api.weixin.qq.com/'
+
     def add(self, product_id, quantity, sku_info=''):
         return self._post(
             'merchant/stock/add',

--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -83,6 +83,13 @@ class BaseWeChatClient(object):
         if url.startswith('https://file.api.weixin.qq.com'):
             kwargs['verify'] = False
 
+        # 微信小店API手册v1.16中将所有请求url进行了修改，去掉了cgi-bin
+        if url_or_endpoint.startswith('merchant/'):
+            url = '{base}{endpoint}'.format(
+                base='https://api.weixin.qq.com/',
+                endpoint=url_or_endpoint
+            )
+
         if 'params' not in kwargs:
             kwargs['params'] = {}
         if isinstance(kwargs['params'], dict) and \

--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -83,13 +83,6 @@ class BaseWeChatClient(object):
         if url.startswith('https://file.api.weixin.qq.com'):
             kwargs['verify'] = False
 
-        # 微信小店API手册v1.16中将所有请求url进行了修改，去掉了cgi-bin
-        if url_or_endpoint.startswith('merchant/'):
-            url = '{base}{endpoint}'.format(
-                base='https://api.weixin.qq.com/',
-                endpoint=url_or_endpoint
-            )
-
         if 'params' not in kwargs:
             kwargs['params'] = {}
         if isinstance(kwargs['params'], dict) and \


### PR DESCRIPTION
1.微信小店API手册v1.16中所有请求url都改成了如下形式

> https://api.weixin.qq.com/merchant/xxx

2.调试中发现获取所有分组API的关键字已更新为'groups_detail'