### PR TITLE
【模板消息】实现一次性订阅消息的API

### DIFF
--- a/tests/test_send_messages.py
+++ b/tests/test_send_messages.py
@@ -3,21 +3,22 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
+from wechatpy import WeChatClient
 from wechatpy.client.api import WeChatMessage
 
 
 class SendMessageTestCase(unittest.TestCase):
     def setUp(self):
-        self.message = WeChatMessage()
+        self.client = WeChatClient('wx1234567887654321', 'secret')
+        self.message = WeChatMessage(self.client)
 
     def test_get_subscribe_authorize_url(self):
-        appid = 'wx1234567887654321'
         scene = 42
         template_id = 'some_long_id'
         redirect_url = 'https://mp.weixin.qq.com'
         reserved = 'random_string'
-        url = self.message.get_subscribe_authorize_url(appid, scene, template_id, redirect_url, reserved)
+        url = self.message.get_subscribe_authorize_url(scene, template_id, redirect_url, reserved)
         base_url = ('https://mp.weixin.qq.com/mp/subscribemsg?action=get_confirm&appid={}&scene={}&template_id={}'
                     '&redirect_url=https%3A%2F%2Fmp.weixin.qq.com&reserved={}#wechat_redirect')
-        expected_url = base_url.format(appid, scene, template_id, reserved)
+        expected_url = base_url.format(self.client.appid, scene, template_id, reserved)
         self.assertEqual(expected_url, url)

--- a/tests/test_send_messages.py
+++ b/tests/test_send_messages.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+from wechatpy.client.api import WeChatMessage
+
+
+class SendMessageTestCase(unittest.TestCase):
+    def setUp(self):
+        self.message = WeChatMessage()
+
+    def test_get_subscribe_authorize_url(self):
+        appid = 'wx1234567887654321'
+        scene = 42
+        template_id = 'some_long_id'
+        redirect_url = 'https://mp.weixin.qq.com'
+        reserved = 'random_string'
+        url = self.message.get_subscribe_authorize_url(appid, scene, template_id, redirect_url, reserved)
+        base_url = ('https://mp.weixin.qq.com/mp/subscribemsg?action=get_confirm&appid={}&scene={}&template_id={}'
+                    '&redirect_url=https%3A%2F%2Fmp.weixin.qq.com&reserved={}#wechat_redirect')
+        expected_url = base_url.format(appid, scene, template_id, reserved)
+        self.assertEqual(expected_url, url)

--- a/wechatpy/client/api/message.py
+++ b/wechatpy/client/api/message.py
@@ -543,3 +543,30 @@ class WeChatMessage(BaseWeChatAPI):
             is_to_all,
             preview
         )
+
+    def send_subscribe_template(self, openid, template_id, url, scene, title, data):
+        """
+        一次性订阅消息，通过API推送订阅模板消息给到授权微信用户。
+        详情请参阅：
+        https://mp.weixin.qq.com/wiki?id=mp1500374289_66bvB
+
+        :param openid: 填接收消息的用户openid
+        :param template_id: 订阅消息模板ID
+        :param url: 点击消息跳转的链接，需要有ICP备案
+        :param scene: 订阅场景值，开发者可以填0-10000的整形值，用来标识订阅场景值
+        :type scene: int
+        :param title: 消息标题，15字以内
+        :param data: 消息正文，value为消息内容，color为颜色，200字以内
+        :type data: dict
+        """
+        return self._post(
+            'message/template/subscribe',
+            data={
+                'touser': openid,
+                'template_id': template_id,
+                'url': url,
+                'scene': scene,
+                'title': title,
+                'data': data,
+            },
+        )

--- a/wechatpy/client/api/message.py
+++ b/wechatpy/client/api/message.py
@@ -2,11 +2,13 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
+import urllib
 
 import six
 from optionaldict import optionaldict
 
 from wechatpy.client.api.base import BaseWeChatAPI
+from wechatpy.utils import random_string
 
 
 class WeChatMessage(BaseWeChatAPI):
@@ -543,6 +545,33 @@ class WeChatMessage(BaseWeChatAPI):
             is_to_all,
             preview
         )
+
+    def get_subscribe_authorize_url(self, appid, scene, template_id, redirect_url, reserved=None):
+        """
+        构造请求用户授权的url
+        详情请参阅：
+        https://mp.weixin.qq.com/wiki?id=mp1500374289_66bvB
+
+        :param appid: 需授权的公众号 AppID
+        :param scene: 订阅场景值，开发者可以填0-10000的整形值，用来标识订阅场景值
+        :type scene: int
+        :param template_id: 订阅消息模板ID，登录公众平台后台，在接口权限列表处可查看订阅模板ID
+        :param redirect_url: 授权后重定向的回调地址
+        :param reserved: 用于保持请求和回调的状态，授权请后原样带回给第三方。该参数可用于防止csrf攻击。若不指定则随机生成。
+        """
+        if reserved is None:
+            reserved = random_string()
+        base_url = 'https://mp.weixin.qq.com/mp/subscribemsg'
+        params = [
+            ('action', 'get_confirm'),
+            ('appid', appid),
+            ('scene', scene),
+            ('template_id', template_id),
+            ('redirect_url', redirect_url),
+            ('reserved', reserved),
+        ]
+        url = '{base}?{params}#wechat_redirect'.format(base=base_url, params=urllib.urlencode(params))
+        return url
 
     def send_subscribe_template(self, openid, template_id, scene, title, data, url=None):
         """

--- a/wechatpy/client/api/message.py
+++ b/wechatpy/client/api/message.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-import urllib
 
 import six
 from optionaldict import optionaldict
@@ -569,7 +568,8 @@ class WeChatMessage(BaseWeChatAPI):
             ('redirect_url', redirect_url),
             ('reserved', reserved),
         ]
-        url = '{base}?{params}#wechat_redirect'.format(base=base_url, params=urllib.urlencode(params))
+        encoded_params = six.moves.urllib.parse.urlencode(params)
+        url = '{base}?{params}#wechat_redirect'.format(base=base_url, params=encoded_params)
         return url
 
     def send_subscribe_template(self, openid, template_id, scene, title, data, url=None):

--- a/wechatpy/client/api/message.py
+++ b/wechatpy/client/api/message.py
@@ -544,7 +544,7 @@ class WeChatMessage(BaseWeChatAPI):
             preview
         )
 
-    def send_subscribe_template(self, openid, template_id, url, scene, title, data):
+    def send_subscribe_template(self, openid, template_id, scene, title, data, url=None):
         """
         一次性订阅消息，通过API推送订阅模板消息给到授权微信用户。
         详情请参阅：
@@ -552,21 +552,24 @@ class WeChatMessage(BaseWeChatAPI):
 
         :param openid: 填接收消息的用户openid
         :param template_id: 订阅消息模板ID
-        :param url: 点击消息跳转的链接，需要有ICP备案
         :param scene: 订阅场景值，开发者可以填0-10000的整形值，用来标识订阅场景值
         :type scene: int
         :param title: 消息标题，15字以内
         :param data: 消息正文，value为消息内容，color为颜色，200字以内
         :type data: dict
+        :param url: 点击消息跳转的链接，需要有ICP备案
         """
+        post_data = {
+            'touser': openid,
+            'template_id': template_id,
+            'url': url,
+            'scene': scene,
+            'title': title,
+            'data': data,
+        }
+        if url is not None:
+            post_data['url'] = url
         return self._post(
             'message/template/subscribe',
-            data={
-                'touser': openid,
-                'template_id': template_id,
-                'url': url,
-                'scene': scene,
-                'title': title,
-                'data': data,
-            },
+            data=post_data,
         )

--- a/wechatpy/client/api/message.py
+++ b/wechatpy/client/api/message.py
@@ -546,13 +546,12 @@ class WeChatMessage(BaseWeChatAPI):
             preview
         )
 
-    def get_subscribe_authorize_url(self, appid, scene, template_id, redirect_url, reserved=None):
+    def get_subscribe_authorize_url(self, scene, template_id, redirect_url, reserved=None):
         """
         构造请求用户授权的url
         详情请参阅：
         https://mp.weixin.qq.com/wiki?id=mp1500374289_66bvB
 
-        :param appid: 需授权的公众号 AppID
         :param scene: 订阅场景值，开发者可以填0-10000的整形值，用来标识订阅场景值
         :type scene: int
         :param template_id: 订阅消息模板ID，登录公众平台后台，在接口权限列表处可查看订阅模板ID
@@ -564,7 +563,7 @@ class WeChatMessage(BaseWeChatAPI):
         base_url = 'https://mp.weixin.qq.com/mp/subscribemsg'
         params = [
             ('action', 'get_confirm'),
-            ('appid', appid),
+            ('appid', self.appid),
             ('scene', scene),
             ('template_id', template_id),
             ('redirect_url', redirect_url),

--- a/wechatpy/enterprise/client/api/oauth.py
+++ b/wechatpy/enterprise/client/api/oauth.py
@@ -15,7 +15,7 @@ class WeChatOAuth(BaseWeChatAPI):
         详情请参考
         http://qydev.weixin.qq.com/wiki/index.php?title=OAuth%E9%AA%8C%E8%AF%81%E6%8E%A5%E5%8F%A3
 
-        :param redirect_url: 授权后重定向的回调链接地址
+        :param redirect_uri: 授权后重定向的回调链接地址
         :param state: 重定向后会带上 state 参数
         :return: 返回的 JSON 数据包
         """


### PR DESCRIPTION
微信新开放的接口，可以在用户授权后推一次强通知。

文档参见：[微信 - 通过API推送订阅模板消息给到授权微信用户](https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1500374289_66bvB)