### PR TITLE
【用户管理】补全黑名单管理相关API

### DIFF
--- a/wechatpy/client/api/tag.py
+++ b/wechatpy/client/api/tag.py
@@ -112,11 +112,8 @@ class WeChatTag(BaseWeChatAPI):
         """
         获取用户身上的标签列表
 
-        :param tag_id: 标签 ID
         :param user_id: 用户 ID, 可以是单个或者列表
-
         :return: 返回的 JSON 数据包
-
         """
         return self._post(
             'tags/getidlist',
@@ -133,13 +130,63 @@ class WeChatTag(BaseWeChatAPI):
         :param tag_id: 标签 ID
         :param first_user_id: 可选。第一个拉取的 OPENID，不填默认从头开始拉取
         :return: 返回的 JSON 数据包
-
         """
-        params = {}
-        params['tagid'] = tag_id
+        params = {
+            'tagid': tag_id,
+        }
         if first_user_id:
             params['next_openid'] = first_user_id
         return self._get(
             'user/tag/get',
             params=params
+        )
+
+    def get_black_list(self, begin_openid=None):
+        """
+        获取公众号的黑名单列表
+        详情请参考
+        https://mp.weixin.qq.com/wiki?id=mp1471422259_pJMWA
+
+        :param begin_openid: 起始的 OpenID，传空则默认从头开始拉取
+        :return: 返回的 JSON 数据包
+        :rtype: dict
+        """
+        data = {}
+        if begin_openid:
+            data['begin_openid'] = begin_openid
+        return self._post(
+            'tags/members/getblacklist',
+            data=data,
+        )
+
+    def batch_black_list(self, openid_list):
+        """
+        批量拉黑用户
+        详情请参考
+        https://mp.weixin.qq.com/wiki?id=mp1471422259_pJMWA
+
+        :param openid_list: 批量拉黑用户的 OpenID list, 最多20个
+        :type openid_list: list
+        """
+        return self._post(
+            'tags/members/batchblacklist',
+            data={
+                'openid_list': openid_list,
+            },
+        )
+
+    def batch_unblack_list(self, openid_list):
+        """
+        批量取消拉黑
+        详情请参考
+        https://mp.weixin.qq.com/wiki?id=mp1471422259_pJMWA
+
+        :param openid_list: 批量取消拉黑的 OpenID list, 最多20个
+        :type openid_list: list
+        """
+        return self._post(
+            'tags/members/batchunblacklist',
+            data={
+                'openid_list': openid_list,
+            },
         )


### PR DESCRIPTION
close #250 

微信文档真的坑，
`openid_list`写成了`opened_list`（手动测试过了）。