### PR TITLE
component_verify_ticket TTL 延长到 20 分钟

### DIFF
--- a/wechatpy/component.py
+++ b/wechatpy/component.py
@@ -417,7 +417,7 @@ class WeChatComponent(BaseWeChatComponent):
         content = self.crypto.decrypt_message(msg, signature, timestamp, nonce)
         message = xmltodict.parse(to_text(content))['xml']
         o = ComponentVerifyTicketMessage(message)
-        self.session.set(o.type, o.verify_ticket, 600)
+        self.session.set(o.type, o.verify_ticket, 1200)
 
     def get_unauthorized(self, msg, signature, timestamp, nonce):
         """


### PR DESCRIPTION
微信服务器每隔10分钟会向第三方的消息接收地址推送一次component_verify_ticket，用于获取第三方平台接口调用凭据。实际每个 component_verify_ticket 的 TTL 应该约等于两次间隔时间。

当前设置存在的问题：
0 时刻推送，存储到 session。 10 分钟时刻失效。推送可能在十分钟延迟一点点，比如 10分5秒成功。
中间的 5 秒钟，就没有 component_verify_ticket。此时调用接口，都是`61006, message: component ticket is invalid hint`错误。
实际上在更新新的 component_verify_ticket 之前，旧的都是可用的。