### PR TITLE
修复 第三方主动发送设备状态消息给微信终端 的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 
 [![Build Status](https://travis-ci.org/jxtech/wechatpy.svg?branch=master)](https://travis-ci.org/jxtech/wechatpy)
 [![Build status](https://ci.appveyor.com/api/projects/status/sluy95tvbe090af1/branch/master?svg=true)](https://ci.appveyor.com/project/messense/wechatpy-den93/branch/master)
-[![codecov.io](http://codecov.io/github/jxtech/wechatpy/coverage.svg?branch=master)](http://codecov.io/github/jxtech/wechatpy?branch=master)
+[![codecov.io](https://codecov.io/github/jxtech/wechatpy/coverage.svg?branch=master)](https://codecov.io/github/jxtech/wechatpy?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jxtech/wechatpy/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/jxtech/wechatpy/?branch=master)
 [![PyPI](https://img.shields.io/pypi/v/wechatpy.svg)](https://pypi.org/project/wechatpy)
-[![Downloads](http://pepy.tech/badge/wechatpy)](http://pepy.tech/project/wechatpy)
+[![Downloads](https://pepy.tech/badge/wechatpy)](https://pepy.tech/project/wechatpy)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjxtech%2Fwechatpy.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fjxtech%2Fwechatpy?ref=badge_shield)
 
 微信(WeChat) 公众平台第三方 Python SDK。
 
-[【阅读文档】](http://wechatpy.readthedocs.org/zh_CN/master/) [【快速入门】](http://wechatpy.readthedocs.org/zh_CN/master/quickstart.html)
+[【阅读文档】](https://wechatpy.readthedocs.org/zh_CN/master/) [【快速入门】](https://wechatpy.readthedocs.org/zh_CN/master/quickstart.html)
 
 [![Join the chat at https://gitter.im/messense/wechatpy](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/messense/wechatpy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/tests/fixtures/qrcode_create.json
+++ b/tests/fixtures/qrcode_create.json
@@ -1,5 +1,5 @@
 {
     "ticket": "gQH47joAAAAAAAAAASxodHRwOi8vd2VpeGluLnFxLmNvbS9xL2taZ2Z3TVRtNzJXV1Brb3ZhYmJJAAIEZ23sUwMEmm3sUw==",
     "expire_seconds": 1800,
-    "url":"http://weixin.qq.com/q/kZgfwMTm72WWPkovabbI"
+    "url":"https://weixin.qq.com/q/kZgfwMTm72WWPkovabbI"
 }

--- a/wechatpy/client/api/device.py
+++ b/wechatpy/client/api/device.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 import base64
 import urllib
 
-from wechatpy.utils import to_text, to_binary
 from wechatpy.client.api.base import BaseWeChatAPI
+from wechatpy.utils import to_binary, to_text
 
 
 class WeChatDevice(BaseWeChatAPI):
-
     API_BASE_URL = 'https://api.weixin.qq.com/device/'
 
     def send_message(self, device_type, device_id, user_id, content):
         """
         主动发送消息给设备
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-3
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-3
 
         :param device_type: 设备类型，目前为“公众账号原始ID”
         :param device_id: 设备ID
@@ -34,11 +34,35 @@ class WeChatDevice(BaseWeChatAPI):
             }
         )
 
+    def send_status_message(self, device_type, device_id, user_id, msg_type, device_status):
+        """
+        第三方主动发送设备状态消息给微信终端
+        详情请参考
+        https://iot.weixin.qq.com/wiki/document-2_10.html
+
+        :param device_type: 设备类型，目前为“公众账号原始ID”
+        :param device_id: 设备ID
+        :param user_id: 微信用户账号的openid
+        :param msg_type: 消息类型：2--设备状态消息
+        :param status: 设备状态：0--未连接， 1--已连接
+        :return: 返回的 JSON 数据包
+        """
+        return self._post(
+            'transmsg',
+            data={
+                'device_type': device_type,
+                'device_id': device_id,
+                'open_id': user_id,
+                'msg_type': msg_type,
+                'device_status': device_status,
+            }
+        )
+
     def create_qrcode(self, device_ids):
         """
         获取设备二维码
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-4
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-4
 
         :param device_ids: 设备id的列表
         :return: 返回的 JSON 数据包
@@ -55,13 +79,13 @@ class WeChatDevice(BaseWeChatAPI):
         """
         通过 ticket 换取二维码地址
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-4
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-4
 
         :param ticket: 二维码 ticket
         :param data: 额外数据
         :return: 二维码地址
         """
-        url = 'http://we.qq.com/d/{ticket}'.format(ticket=ticket)
+        url = 'https://we.qq.com/d/{ticket}'.format(ticket=ticket)
         if data:
             if isinstance(data, (dict, tuple, list)):
                 data = urllib.urlencode(data)
@@ -73,7 +97,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         绑定设备
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
 
         :param ticket: 绑定操作合法性的凭证（由微信后台生成，第三方H5通过客户端jsapi获得）
         :param device_id: 设备id
@@ -93,7 +117,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         解绑设备
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
 
         :param ticket: 绑定操作合法性的凭证（由微信后台生成，第三方H5通过客户端jsapi获得）
         :param device_id: 设备id
@@ -113,7 +137,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         强制绑定用户和设备
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
 
         :param device_id: 设备id
         :param user_id: 用户对应的openid
@@ -133,7 +157,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         强制解绑用户和设备
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-7
 
         :param device_id: 设备id
         :param user_id: 用户对应的openid
@@ -153,7 +177,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         设备状态查询
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-8
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-8
 
         :param device_id: 设备id
         :return: 返回的 JSON 数据包
@@ -167,7 +191,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         验证二维码
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-9
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-9
 
         :param ticket: 设备二维码的ticket
         :return: 返回的 JSON 数据包
@@ -181,7 +205,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         获取设备绑定openID
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-11
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-11
 
         :param device_type: 设备类型，目前为“公众账号原始ID”
         :param device_id: 设备id
@@ -201,7 +225,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         通过openid获取用户在当前devicetype下绑定的deviceid列表
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-12
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-12
 
         :param user_id: 要查询的用户的openid
         :return: 返回的 JSON 数据包
@@ -213,33 +237,11 @@ class WeChatDevice(BaseWeChatAPI):
 
     get_bind_device = get_binded_devices
 
-    def send_status_message(self, device_type, device_id, user_id, status):
-        """
-        主动发送设备状态消息给微信终端
-        详情请参考
-        http://iot.weixin.qq.com/document-2_10.html
-
-        :param device_type: 设备类型，目前为“公众账号原始ID”
-        :param device_id: 设备ID
-        :param user_id: 微信用户账号的openid
-        :param status: 设备状态：0--未连接， 1--已连接
-        :return: 返回的 JSON 数据包
-        """
-        return self._post(
-            'transmsg',
-            data={
-                'device_type': device_type,
-                'device_id': device_id,
-                'open_id': user_id,
-                'device_status': status
-            }
-        )
-
     def get_qrcode(self, product_id=1):
         """
         获取deviceid和二维码
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-4
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-4
 
         :param product_id: 设备的产品编号
         :return: 返回的 JSON 数据包
@@ -255,7 +257,7 @@ class WeChatDevice(BaseWeChatAPI):
         """
         设备授权
         详情请参考
-        http://iot.weixin.qq.com/wiki/new/index.html?page=3-4-5
+        https://iot.weixin.qq.com/wiki/new/index.html?page=3-4-5
 
         :param devices: 设备信息的列表
         :param op_type: 请求操作的类型，限定取值为：0：设备授权 1：设备更新

--- a/wechatpy/client/api/device.py
+++ b/wechatpy/client/api/device.py
@@ -29,7 +29,7 @@ class WeChatDevice(BaseWeChatAPI):
             data={
                 'device_type': device_type,
                 'device_id': device_id,
-                'openid': user_id,
+                'open_id': user_id,
                 'content': content
             }
         )

--- a/wechatpy/replies.py
+++ b/wechatpy/replies.py
@@ -301,7 +301,7 @@ class DeviceStatusReply(BaseReply):
     type = 'device_status'
     device_type = StringField('DeviceType')
     device_id = StringField('DeviceID')
-    status = StringField('DeviceStatus')
+    status = IntegerField('DeviceStatus')
 
 
 @register_reply('hardware')


### PR DESCRIPTION
Closes #284 

Fix：
主动发送消息给设备 参数错误
第三方主动发送设备状态消息给微信终端 参数错误
`replies.py`类型定义错误

Refactor：
* device.py 下接口全部使用 HTTPS。
* `transmsg`两个接口放在一起，结构更清晰。