### PR TITLE
新功能: 获取所有用户的openid

### DIFF
--- a/wechatpy/client/api/user.py
+++ b/wechatpy/client/api/user.py
@@ -76,7 +76,7 @@ class WeChatUser(BaseWeChatAPI):
             from wechatpy import WeChatClient
 
             client = WeChatClient('appid', 'secret')
-            for openid in client.user.get_followers():
+            for openid in client.user.iter_followers():
                 print(openid)
 
         """

--- a/wechatpy/client/api/user.py
+++ b/wechatpy/client/api/user.py
@@ -38,7 +38,7 @@ class WeChatUser(BaseWeChatAPI):
 
     def get_followers(self, first_user_id=None):
         """
-        获取用户列表
+        获取一页用户列表(当关注用户过多的情况下，这个接口只会返回一部分用户)
 
         详情请参考
         https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140840
@@ -61,6 +61,38 @@ class WeChatUser(BaseWeChatAPI):
             'user/get',
             params=params
         )
+
+    def iter_followers(self):
+        """
+        获取所有的用户openid列表
+
+        详情请参考
+        https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140840
+
+        :return: 返回一个迭代器，可以用for进行循环，得到openid
+
+        使用示例::
+
+            from wechatpy import WeChatClient
+
+            client = WeChatClient('appid', 'secret')
+            for openid in client.user.get_followers():
+                print(openid)
+
+        """
+        while True:
+            first_user_id = getattr(self, "_current_iter_openid", None)
+            follower_data = self.get_followers(first_user_id)
+            # 微信有个bug(或者叫feature)，没有下一页，也返回next_openid这个字段
+            # 所以要通过total_count和data的长度比较判断(比较麻烦，并且不稳定)
+            # 或者获得结果前先判断data是否存在
+            if 'data' not in follower_data:
+                raise StopIteration
+            self._current_iter_openid = follower_data["next_openid"]
+            for openid in follower_data['data']['openid']:
+                yield openid
+            if not follower_data['next_openid']:
+                raise StopIteration
 
     def update_remark(self, user_id, remark):
         """

--- a/wechatpy/client/api/user.py
+++ b/wechatpy/client/api/user.py
@@ -80,18 +80,18 @@ class WeChatUser(BaseWeChatAPI):
                 print(openid)
 
         """
+        first_user_id = None
         while True:
-            first_user_id = getattr(self, "_current_iter_openid", None)
             follower_data = self.get_followers(first_user_id)
+            first_user_id = follower_data["next_openid"]
             # 微信有个bug(或者叫feature)，没有下一页，也返回next_openid这个字段
             # 所以要通过total_count和data的长度比较判断(比较麻烦，并且不稳定)
             # 或者获得结果前先判断data是否存在
             if 'data' not in follower_data:
                 raise StopIteration
-            self._current_iter_openid = follower_data["next_openid"]
             for openid in follower_data['data']['openid']:
                 yield openid
-            if not follower_data['next_openid']:
+            if not first_user_id:
                 raise StopIteration
 
     def update_remark(self, user_id, remark):


### PR DESCRIPTION
[微信文档](https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140840):
> 公众号可通过本接口来获取帐号的关注者列表，关注者列表由一串OpenID（加密后的微信号，每个用户对每个公众号的OpenID是唯一的）组成。一次拉取调用最多拉取10000个关注者的OpenID，可以通过多次拉取的方式来满足需求。


所以在调用原来的`wechatpy.client.api.WeChatUser.get_followers`的时候，如果关注者超过10000个，就会返回数据不全的状况。为了方便使用，我创建了一个`wechatpy.client.api.WeChatUser.iter_followers`函数，可以用来迭代关注者的用户openid