### PR TITLE
强制转换为int

### DIFF
--- a/wechatpy/client/api/jsapi.py
+++ b/wechatpy/client/api/jsapi.py
@@ -83,7 +83,7 @@ class WeChatJSAPI(BaseWeChatAPI):
 
         ticket = self.session.get(jsapi_card_ticket_key)
         expires_at = self.session.get(jsapi_card_ticket_expire_at_key, 0)
-        if not ticket or expires_at < int(time.time()):
+        if not ticket or int(expires_at) < int(time.time()):
             ticket_response = self.get_ticket('wx_card')
             ticket = ticket_response['ticket']
             expires_at = int(time.time()) + int(ticket_response['expires_in'])


### PR DESCRIPTION
self.session.get得到值，可能都是str。就不会出现str < int为false的情况出现。
转变为int的更适用些