### PR TITLE
A addition code_to_session function.

### DIFF
--- a/tests/fixtures/sns_jscode2session.json
+++ b/tests/fixtures/sns_jscode2session.json
@@ -1,0 +1,6 @@
+{
+  "session_key": "D1ZWEygStjuLCnZ9IN2l4Q==",
+  "expires_in": 7200,
+  "openid": "o16wA0b4AZKzgVJR3MBwoUdTfU_E",
+  "unionid": "or4zX05h_Ykt4ju0TUfx3CQsvfTo"
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -854,3 +854,11 @@ class WeChatClientTestCase(unittest.TestCase):
         self.assertEqual(2, len(res))
         self.assertEqual('o2FwqwI9xCsVadFah_HtpPfaR-X4', res[0]['new_openid'])
         self.assertEqual('ori_openid error', res[1]['err_msg'])
+
+    def test_code_to_session(self):
+        with HTTMock(wechat_api_mock):
+            res = self.client.wxa.code_to_session('023dUeGW1oeGOZ0JXvHW1SDVFW1dUeGu')
+        self.assertIn('session_key', res)
+        self.assertEqual('D1ZWEygStjuLCnZ9IN2l4Q==', res['session_key'])
+        self.assertEqual('o16wA0b4AZKzgVJR3MBwoUdTfU_E', res['openid'])
+        self.assertEqual('or4zX05h_Ykt4ju0TUfx3CQsvfTo', res['unionid'])

--- a/wechatpy/client/api/base.py
+++ b/wechatpy/client/api/base.py
@@ -28,3 +28,7 @@ class BaseWeChatAPI(object):
     @property
     def appid(self):
         return self._client.appid
+
+    @property
+    def secret(self):
+        return self._client.secret

--- a/wechatpy/client/api/wxa.py
+++ b/wechatpy/client/api/wxa.py
@@ -436,3 +436,22 @@ class WeChatWxa(BaseWeChatAPI):
                 'open_appid': open_appid,
             }
         )
+
+    def code_to_session(self, js_code):
+        """
+        登录凭证校验。通过 wx.login() 接口获得临时登录凭证 code 后传到开发者服务器调用此接口完成登录流程。更多使用方法详见 小程序登录
+        详情请参考
+        https://developers.weixin.qq.com/miniprogram/dev/api/code2Session.html
+
+        :param js_code:
+        :return:
+        """
+        return self._get(
+            'sns/jscode2session',
+            params={
+                'appid': self.appid,
+                'secret': self.secret,
+                'js_code': js_code,
+                'grant_type': 'authorization_code'
+            }
+        )


### PR DESCRIPTION
> code_to_session( js_code)

  登录凭证校验。通过 wx.login() 接口获得临时登录凭证 code 后传到开发者服务器调用此接口完成登录流程。更多使用方法详见 小程序登录,详情请参考https://developers.weixin.qq.com/miniprogram/dev/api/code2Session.html

参数

- js_code **( str)** – js_code 为 登录时获取的 code。

| 属性    | 类型   | 说明              |
| ------- | ------ | ----------------- |
| js_code | string | 登录时获取的 code |

返回:

| 属性        | 类型   | 说明                                                         |
| ----------- | ------ | ------------------------------------------------------------ |
| openid      | string | 用户唯一标识                                                 |
| session_key | string | 会话密钥                                                     |
| unionid     | string | 用户在开放平台的唯一标识符，在满足 UnionID 下发条件的情况下会返回，详见 [UnionID 机制说明](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/union-id.html)。 |
| errcode     | number | 错误码                                                       |
| errmsg      | string | 错误信息                                                     |

示例

```
from wechatpy import WeChatClient
client = WeChatClient('appid', 'secret')
js_code = ''
client.wxa.code_to_session(js_code)
```