### PR TITLE
_http变为WeChatPay实例的属性，解决创建多个实例，发送请求时数据会串的问题

### DIFF
--- a/wechatpy/pay/__init__.py
+++ b/wechatpy/pay/__init__.py
@@ -37,7 +37,6 @@ class WeChatPay(object):
     :param timeout: 可选，请求超时时间，单位秒，默认无超时设置
     :param sandbox: 可选，是否使用测试环境，默认为 False
     """
-    _http = requests.Session()
 
     redpack = api.WeChatRedpack()
     """红包接口"""
@@ -81,6 +80,7 @@ class WeChatPay(object):
         self.timeout = timeout
         self.sandbox = sandbox
         self._sandbox_api_key = None
+        self._http = requests.Session()
 
     def _fetch_sandbox_api_key(self):
         nonce_str = random_string(32)


### PR DESCRIPTION
class Client(Enum):
    WECHAT = '微信网页'
    APP = 'app'

def get_wechat_pay(client=Client.WECHAT.name):
    """
    appid – 微信公众号 appid
    api_key – 商户 key
    mch_id – 商户号
    sub_mch_id – 可选，子商户号，受理模式下必填
    mch_cert – 必填，商户证书路径
    mch_key – 必填，商户证书私钥路径
    timeout – 可选，请求超时时间，单位秒，默认无超时设置
    sandbox – 可选，是否使用测试环境，默认为 False
    """
    if client == Client.WECHAT.name:
        appid = settings.WECHAT_APP_ID
        api_key = settings.WECHAT_PAY_API_KEY
        mch_id = settings.WECHAT_PAY_MCH_ID
        sub_mch_id = settings.WECHAT_PAY_SUB_MCH_ID
        mch_cert = settings.WECHAT_PAY_MCH_CERT
        mch_key = settings.WECHAT_PAY_MCH_KEY
        timeout = settings.WECHAT_PAY_TIMEOUT
        sandbox = settings.WECHAT_PAY_SANDBOX
    else:
        appid = settings.APP_WECHAT_PAY_APP_ID
        api_key = settings.APP_WECHAT_PAY_MAC_API_KEY
        mch_id = settings.APP_WECHAT_PAY_MCH_ID
        sub_mch_id = settings.WECHAT_PAY_SUB_MCH_ID
        mch_cert = settings.APP_WECHAT_PAY_MCH_CERT
        mch_key = settings.APP_WECHAT_PAY_MCH_KEY
        timeout = settings.WECHAT_PAY_TIMEOUT
        sandbox = settings.WECHAT_PAY_SANDBOX

    return WeChatPay(
        appid=appid,
        api_key=api_key,
        mch_id=mch_id,
        sub_mch_id=sub_mch_id,
        mch_cert=mch_cert,
        mch_key=mch_key,
        timeout=timeout,
        sandbox=sandbox)

openid = 'aaa'
app_openid = 'bbb'

wechat_pay = get_wechat_pay()
wechat_pay.transfer.transfer(
    openid, 100, '公众号企业付款', check_name='NO_CHECK', out_trade_no=str(uuid4()).replace('-',
    ''))

app_pay = get_wechat_pay(Client.APP.name)
app_pay.transfer.transfer(        #这个调用会报证书错误，因为当前WeChatPay的_http是个类属性，证书应该还是用的wechat_pay的证书
    app_openid,
    100,
    'app企业付款',
    check_name='NO_CHECK',
    out_trade_no=str(uuid4()).replace('-', ''))