### PR TITLE
iter_tag_users and fixes #425

### DIFF
--- a/tests/fixtures/user_tag_get.json
+++ b/tests/fixtures/user_tag_get.json
@@ -1,5 +1,4 @@
 {
-    "total":2,
     "count":2,
     "data": {"openid": ["OPENID1", "OPENID2"]},
     "next_openid":"OPENID2"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -262,8 +262,8 @@ class WeChatClientTestCase(unittest.TestCase):
         def next_openid_mock(url, request):
             """伪造第二页的请求"""
             content = {
-                "total":2,
-                "count":0,
+                "total": 2,
+                "count": 0,
                 "next_openid": ""
             }
             headers = {
@@ -327,7 +327,7 @@ class WeChatClientTestCase(unittest.TestCase):
 
             # 根据拿到的第二页请求响应 是没有data和next_openid的
             content = {
-                "count":0
+                "count": 0
             }
             headers = {
                 'Content-Type': 'application/json'

--- a/wechatpy/client/api/tag.py
+++ b/wechatpy/client/api/tag.py
@@ -141,6 +141,31 @@ class WeChatTag(BaseWeChatAPI):
             data=data
         )
 
+    def iter_tag_users(self, tag_id, first_user_id=None):
+        """
+        获取标签下粉丝openid列表
+
+        :return: 返回一个迭代器，可以用for进行循环，得到openid
+
+        使用示例::
+
+            from wechatpy import WeChatClient
+
+            client = WeChatClient('appid', 'secret')
+            for openid in client.tag.iter_tag_users(0):
+                print(openid)
+
+        """
+        while True:
+            follower_data = self.get_tag_users(tag_id, first_user_id)
+            if 'data' not in follower_data:
+                return
+            for openid in follower_data['data']['openid']:
+                yield openid
+            first_user_id = follower_data.get('next_openid')
+            if not first_user_id:
+                return
+
     def get_black_list(self, begin_openid=None):
         """
         获取公众号的黑名单列表

--- a/wechatpy/client/api/user.py
+++ b/wechatpy/client/api/user.py
@@ -62,7 +62,7 @@ class WeChatUser(BaseWeChatAPI):
             params=params
         )
 
-    def iter_followers(self):
+    def iter_followers(self, first_user_id=None):
         """
         获取所有的用户openid列表
 
@@ -80,7 +80,6 @@ class WeChatUser(BaseWeChatAPI):
                 print(openid)
 
         """
-        first_user_id = None
         while True:
             follower_data = self.get_followers(first_user_id)
             first_user_id = follower_data["next_openid"]
@@ -88,11 +87,11 @@ class WeChatUser(BaseWeChatAPI):
             # 所以要通过total_count和data的长度比较判断(比较麻烦，并且不稳定)
             # 或者获得结果前先判断data是否存在
             if 'data' not in follower_data:
-                raise StopIteration
+                return
             for openid in follower_data['data']['openid']:
                 yield openid
             if not first_user_id:
-                raise StopIteration
+                return
 
     def update_remark(self, user_id, remark):
         """


### PR DESCRIPTION
1. 用return代替StopIteration以避免在python 3.7中出现RuntimeError;
2. 增加iter_tag_users方法,获取所有某标签下用户列表;
3. 将iter_followers方法的first_user_id变为传参,当用户持有last_openid时,可选增量获取用户.