### PR TITLE
Fix WeChatMessage.send_markdown

### DIFF
--- a/wechatpy/enterprise/client/api/message.py
+++ b/wechatpy/enterprise/client/api/message.py
@@ -266,10 +266,10 @@ class WeChatMessage(BaseWeChatAPI):
             "msgtype": "markdown",
             "markdown": {"content": content}
         }
-        return self._send_message(
-            agent_id=agent_id,
-            user_ids=user_ids,
-            party_ids=party_ids,
-            tag_ids=tag_ids,
+        return self.send(
+            agent_id,
+            user_ids,
+            party_ids,
+            tag_ids,
             msg=msg
         )


### PR DESCRIPTION
1. replace discarded method with `send`,  [ref commit here](https://github.com/jxtech/wechatpy/commit/c876a71c5f21f3a5449abed72a5656b5e5c1b13c#diff-8d5d79095778bde1f0cd139596ba9d90)
2. unify params used as other methods