### PR TITLE
添加一个直接通过xml获取appid的函数

### DIFF
--- a/wechatpy/pay/__init__.py
+++ b/wechatpy/pay/__init__.py
@@ -194,15 +194,21 @@ class WeChatPay(object):
         return _check_signature(params, self.api_key if not self.sandbox else self.sandbox_api_key)
 
     @classmethod
-    def get_payment_appid(cls, xml):
+    def get_payment_data(cls, xml):
         """
-        解析微信支付结果通知，单独返回appid
+        解析微信支付结果通知，获得appid, mch_id, out_trade_no, transaction_id
+        如果你需要进一步判断，请先用appid, mch_id来生成WeChatPay,
+        然后用`wechatpay.parse_payment_result(xml)`来校验支付结果
 
         使用示例::
 
             from wechatpy.pay import WeChatPay
             # 假设你已经获取了微信服务器推送的请求中的xml数据并存入xml变量
-            WeChatPay.get_payment_appid(xml)
+            data = WeChatPay.get_payment_appid(xml)
+            {
+                "appid": "公众号或者小程序的id",
+                "mch_id": "商户id",
+            }
 
         """
         try:
@@ -211,8 +217,12 @@ class WeChatPay(object):
             raise InvalidSignatureException()
         if not data or 'xml' not in data:
             raise InvalidSignatureException()
-        data = data['xml']
-        return data['appid']
+        return {
+            "appid": data["appid"],
+            "mch_id": data["mch_id"],
+            "out_trade_no": data["out_trade_no"],
+            "transaction_id": data["transaction_id"],
+        }
 
     def parse_payment_result(self, xml):
         """解析微信支付结果通知"""

--- a/wechatpy/pay/__init__.py
+++ b/wechatpy/pay/__init__.py
@@ -193,6 +193,27 @@ class WeChatPay(object):
     def check_signature(self, params):
         return _check_signature(params, self.api_key if not self.sandbox else self.sandbox_api_key)
 
+    @classmethod
+    def get_payment_appid(cls, xml):
+        """
+        解析微信支付结果通知，单独返回appid
+
+        使用示例::
+
+            from wechatpy.pay import WeChatPay
+            # 假设你已经获取了微信服务器推送的请求中的xml数据并存入xml变量
+            WeChatPay.get_payment_appid(xml)
+
+        """
+        try:
+            data = xmltodict.parse(xml)
+        except (xmltodict.ParsingInterrupted, ExpatError):
+            raise InvalidSignatureException()
+        if not data or 'xml' not in data:
+            raise InvalidSignatureException()
+        data = data['xml']
+        return data['appid']
+
     def parse_payment_result(self, xml):
         """解析微信支付结果通知"""
         try:

--- a/wechatpy/pay/__init__.py
+++ b/wechatpy/pay/__init__.py
@@ -214,9 +214,9 @@ class WeChatPay(object):
         try:
             data = xmltodict.parse(xml)
         except (xmltodict.ParsingInterrupted, ExpatError):
-            raise InvalidSignatureException()
+            raise ValueError("invalid xml")
         if not data or 'xml' not in data:
-            raise InvalidSignatureException()
+            raise ValueError("invalid xml")
         return {
             "appid": data["appid"],
             "mch_id": data["mch_id"],


### PR DESCRIPTION
我们公司开发时，有2个公众号和2个小程序。回调请求都设置成一样的了。所以在解析这个xml之前，不知道appid是什么，所以无法调用创建WeChatPay对象，也就无法使用`wechatpay.parse_payment_result`了。所以我加了这个`get_payment_appid`函数可以仅仅通过xml获取appid