### PR TITLE
关闭 Pull Request Codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,9 +37,9 @@ jobs:
         run: tox -e $TOX_ENV
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
+        if: github.event_name == 'push'
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false


### PR DESCRIPTION
Fixes #541

GitHub Actions 不会把加密变量在 fork 的 PR 中加载。