### PR TITLE
body解析编码使用 utf-8-sig

### DIFF
--- a/wechatpy/pay/__init__.py
+++ b/wechatpy/pay/__init__.py
@@ -148,7 +148,7 @@ class WeChatPay:
         return self._handle_result(res)
 
     def _handle_result(self, res):
-        res.encoding = "utf-8"
+        res.encoding = "utf-8-sig"
         xml = res.text
         logger.debug("Response from WeChat API \n %s", xml)
         try:


### PR DESCRIPTION
今天获取对账单发现对账单返回的数据是带bom的，utf-8-sig 无bom数据也可以正常处理，建议改成这个