### PR TITLE
Cleanup schemes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -90,7 +90,7 @@ test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "
 [[package]]
 category = "main"
 description = "A backport of the dataclasses module for Python 3.6"
-marker = "python_version > \"3.5\" and python_version < \"3.7\""
+marker = "python_version >= \"3.6\" and python_version < \"3.7\""
 name = "dataclasses"
 optional = false
 python-versions = ">=3.6, <3.7"
@@ -415,7 +415,7 @@ cryptography = ["cryptography"]
 pycrypto = ["pycryptodome"]
 
 [metadata]
-content-hash = "7769dd2ee466de85f6edc8cf074d26f533fc5b9744160906a6d67c9ce22a8f80"
+content-hash = "c76ff2cf11edae6a445b24889d1a379ce606162280ae8a303b0669ae4acf58fc"
 python-versions = ">=3.6,<4"
 
 [metadata.files]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -507,26 +507,6 @@ class WeChatClientTestCase(unittest.TestCase):
                 "bxLdikRXVbTPdHSM05e5u5sUoXNKd8-41ZO3MhKoyN5OfkWITDGgnr2fwJ0m9E8NYzWKVZvdVtaUgWvsdshFKA",
             )
 
-    def test_jsapi_get_jsapi_card_params(self):
-        """微信签名测试工具：http://mp.weixin.qq.com/debug/cgi-bin/sandbox?t=cardsign"""
-        noncestr = "Wm3WZYTPz0wzccnW"
-        card_ticket = "sM4AOVdWfPE4DxkXGEs8VMCPGGVi4C3VM0P37wVUCFvkVAy_90u5h9nbSlYy3-Sl-HhTdfl2fzFy1AOcHKP7qg"
-        timestamp = 1414587457
-        signature_dict = self.client.jsapi.get_jsapi_card_params(
-            noncestr=noncestr, card_ticket=card_ticket, timestamp=timestamp, card_type="GROUPON",
-        )
-        self.assertEqual(
-            {
-                "card_type": "GROUPON",
-                "noncestr": "Wm3WZYTPz0wzccnW",
-                "api_ticket": "sM4AOVdWfPE4DxkXGEs8VMCPGGVi4C3VM0P37wVUCFvkVAy_90u5h9nbSlYy3-Sl-HhTdfl2fzFy1AOcHKP7qg",
-                "appid": "123456",
-                "timestamp": 1414587457,
-                "sign": "c47b1fb500eb35d8f2f9b9375b4491089df953e2",
-            },
-            signature_dict,
-        )
-
     def test_jsapi_get_jsapi_add_card_params(self):
         """微信签名测试工具：http://mp.weixin.qq.com/debug/cgi-bin/sandbox?t=cardsign"""
         nonce_str = "Wm3WZYTPz0wzccnW"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,7 @@ from httmock import HTTMock, response, urlmatch
 
 from wechatpy import WeChatClient
 from wechatpy.exceptions import WeChatClientException
-from wechatpy.schemes import JsapiCardExt
+from wechatpy.schemes import JsApiCardExt
 
 _TESTS_PATH = os.path.abspath(os.path.dirname(__file__))
 _FIXTURE_PATH = os.path.join(_TESTS_PATH, "fixtures")
@@ -527,14 +527,6 @@ class WeChatClientTestCase(unittest.TestCase):
             signature_dict,
         )
 
-    def test_jsapi_card_ext(self):
-        card_ext = JsapiCardExt("asdf", openid="2")
-        self.assertNotIn("outer_str", card_ext.dict())
-        self.assertNotIn("code", card_ext.dict())
-
-        card_ext = JsapiCardExt("asdf", code="4", openid="2")
-        self.assertIn("code", card_ext.dict())
-
     def test_jsapi_get_jsapi_add_card_params(self):
         """微信签名测试工具：http://mp.weixin.qq.com/debug/cgi-bin/sandbox?t=cardsign"""
         nonce_str = "Wm3WZYTPz0wzccnW"
@@ -549,48 +541,50 @@ class WeChatClientTestCase(unittest.TestCase):
             card_ticket=card_ticket, timestamp=timestamp, card_id=card_id, nonce_str=nonce_str
         )
         self.assertEqual(
-            {"nonce_str": nonce_str, "timestamp": timestamp, "signature": "22dce6bad4db532d4a2ef82ca2ca7bbe1e10ef28",},
-            card_params.dict(),
+            JsApiCardExt(
+                signature="22dce6bad4db532d4a2ef82ca2ca7bbe1e10ef28", nonce_str=nonce_str, timestamp=timestamp,
+            ),
+            card_params,
         )
         # 测试自定义code
         card_params = self.client.jsapi.get_jsapi_add_card_params(
             card_ticket=card_ticket, timestamp=timestamp, card_id=card_id, nonce_str=nonce_str, code=code
         )
-        self.assertDictEqual(
-            {
-                "nonce_str": nonce_str,
-                "timestamp": timestamp,
-                "code": code,
-                "signature": "2e9c6d12952246e071717d7baeab20c30420b5cd",
-            },
-            card_params.dict(),
+        self.assertEqual(
+            JsApiCardExt(
+                nonce_str=nonce_str,
+                timestamp=timestamp,
+                code=code,
+                signature="2e9c6d12952246e071717d7baeab20c30420b5cd",
+            ),
+            card_params,
         )
         # 测试指定用户领取
         card_params = self.client.jsapi.get_jsapi_add_card_params(
             card_ticket=card_ticket, timestamp=timestamp, card_id=card_id, nonce_str=nonce_str, openid=openid
         )
         self.assertEqual(
-            {
-                "nonce_str": nonce_str,
-                "timestamp": timestamp,
-                "openid": openid,
-                "signature": "ded860a5dd4467312764bd86e544ad0579cbfad0",
-            },
-            card_params.dict(),
+            JsApiCardExt(
+                nonce_str=nonce_str,
+                timestamp=timestamp,
+                openid=openid,
+                signature="ded860a5dd4467312764bd86e544ad0579cbfad0",
+            ),
+            card_params,
         )
         # 测试指定用户领取且自定义code
         card_params = self.client.jsapi.get_jsapi_add_card_params(
             card_ticket=card_ticket, timestamp=timestamp, card_id=card_id, nonce_str=nonce_str, openid=openid, code=code
         )
         self.assertEqual(
-            {
-                "nonce_str": nonce_str,
-                "timestamp": timestamp,
-                "openid": openid,
-                "code": code,
-                "signature": "950dc1842852457ea573d4d6af34879c1ec093c8",
-            },
-            card_params.dict(),
+            JsApiCardExt(
+                nonce_str=nonce_str,
+                timestamp=timestamp,
+                openid=openid,
+                code=code,
+                signature="950dc1842852457ea573d4d6af34879c1ec093c8",
+            ),
+            card_params,
         )
 
     def test_menu_get_menu_info(self):

--- a/wechatpy/client/api/jsapi.py
+++ b/wechatpy/client/api/jsapi.py
@@ -12,10 +12,11 @@
 
 import hashlib
 import time
+from typing import Optional
 
 from wechatpy.utils import WeChatSigner, random_string
 from wechatpy.client.api.base import BaseWeChatAPI
-from wechatpy.schemes import JsapiCardExt
+from wechatpy.schemes import JsApiCardExt
 
 
 class WeChatJSAPI(BaseWeChatAPI):
@@ -113,12 +114,12 @@ class WeChatJSAPI(BaseWeChatAPI):
         card_id: str,
         code: str = "",
         openid: str = "",
-        fixed_begintimestamp: int = 0,
+        fixed_begintimestamp: Optional[int] = None,
         outer_str: str = "",
         nonce_str: str = "",
         timestamp: int = 0,
         card_ticket: str = "",
-    ) -> JsapiCardExt:
+    ) -> JsApiCardExt:
         """
         用于生成 jsapi 批量添加卡券接口的 cardList 参数中的 cardExt 参数
         参数意义见微信文档地址：
@@ -152,7 +153,7 @@ class WeChatJSAPI(BaseWeChatAPI):
         }
         list_before_sign = sorted([str(x) for x in card_signature_dict.values()])
         str_to_sign = "".join(list_before_sign).encode()
-        card_ext = JsapiCardExt(
+        card_ext = JsApiCardExt(
             code=code,
             openid=openid,
             timestamp=str(timestamp),

--- a/wechatpy/client/api/jsapi.py
+++ b/wechatpy/client/api/jsapi.py
@@ -89,26 +89,6 @@ class WeChatJSAPI(BaseWeChatAPI):
             self.session.set(jsapi_card_ticket_expire_at_key, expires_at)
         return ticket
 
-    def get_jsapi_card_params(self, card_ticket, card_type, **kwargs):
-        """
-        参数意义见微信文档地址：https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/JS-SDK.html#62
-        :param card_ticket: 用于卡券的微信 api_ticket
-        :param card_type:
-        :param kwargs: 非必须参数：noncestr, timestamp, code, openid, fixed_begintimestamp, outer_str
-        :return: 包含调用jssdk所有所需参数的 dict
-        """
-        card_signature_dict = {
-            "card_type": card_type,
-            "noncestr": kwargs.get("noncestr", random_string()),
-            "api_ticket": card_ticket,
-            "appid": self.appid,
-            "timestamp": kwargs.get("timestamp", str(int(time.time()))),
-        }
-        list_before_sign = sorted([str(x) for x in card_signature_dict.values()])
-        str_to_sign = "".join(list_before_sign).encode()
-        card_signature_dict["sign"] = hashlib.sha1(str_to_sign).hexdigest()
-        return card_signature_dict
-
     def get_jsapi_add_card_params(
         self,
         card_id: str,


### PR DESCRIPTION
1. 使用 `dataclasses.asdict()` 替换自定义的 `dict()` 方法
2. 移除 `dump()` 函数，用户可以自行选择要用的 json 库直接调用 `json.dumps(x.to_dict())`

cc @myuanz