### PR TITLE
补全企业微信的oa接口

### DIFF
--- a/tests/fixtures/work/checkin_getcheckindata.json
+++ b/tests/fixtures/work/checkin_getcheckindata.json
@@ -1,0 +1,32 @@
+{
+   "errcode":0,
+   "errmsg":"ok",
+   "checkindata": [{
+        "userid" : "james",
+        "groupname" : "打卡一组",
+        "checkin_type" : "上班打卡",
+        "exception_type" : "地点异常",
+        "checkin_time" : 1492617610,
+        "location_title" : "依澜府",
+        "location_detail" : "四川省成都市武侯区益州大道中段784号附近",
+        "wifiname" : "办公一区",
+        "notes" : "路上堵车，迟到了5分钟",
+        "wifimac" : "3c:46:d8:0c:7a:70",
+        "mediaids":["WWCISP_G8PYgRaOVHjXWUWFqchpBqqqUpGj0OyR9z6WTwhnMZGCPHxyviVstiv_2fTG8YOJq8L8zJT2T2OvTebANV-2MQ"]
+    },{
+        "userid" : "paul",
+        "groupname" : "打卡二组",
+        "checkin_type" : "外出打卡",
+        "exception_type" : "时间异常",
+        "checkin_time" : 1492617620,
+        "location_title" : "重庆出口加工区",
+        "location_detail" : "重庆市渝北区金渝大道101号金渝大道",
+        "wifiname" : "办公室二区",
+        "notes" : "",
+        "wifimac" : "3c:46:d8:0c:7a:71",
+        "mediaids":["WWCISP_G8PYgRaOVHjXWUWFqchpBqqqUpGj0OyR9z6WTwhnMZGCPHxyviVstiv_2fTG8YOJq8L8zJT2T2OvTebANV-2MQ"],
+        "lat": 30547645,
+        "lng": 104063236,
+        "deviceid":"E5FA89F6-3926-4972-BE4F-4A7ACF4701E2"
+    }]
+}

--- a/tests/fixtures/work/checkin_getcheckinoption.json
+++ b/tests/fixtures/work/checkin_getcheckinoption.json
@@ -1,0 +1,94 @@
+{
+    "errcode": 0,
+    "errmsg": "ok",
+    "info": [
+        {
+            "userid": "james",
+            "group": {
+                "grouptype": 1,
+                "groupid": 69,
+                "checkindate": [
+                    {
+                        "workdays": [
+                            1,
+                            2,
+                            3,
+                            4,
+                            5
+                        ],
+                        "checkintime": [
+                            {
+                                "work_sec": 36000,
+                                "off_work_sec": 43200,
+                                "remind_work_sec": 35400,
+                                "remind_off_work_sec": 43200
+                            },
+                            {
+                                "work_sec": 50400,
+                                "off_work_sec": 72000,
+                                "remind_work_sec": 49800,
+                                "remind_off_work_sec": 72000
+                            }
+                        ],
+                        "flex_time": 300000,
+                        "noneed_offwork": true,
+                        "limit_aheadtime": 10800000
+                    }
+                ],
+                "spe_workdays": [
+                    {
+                        "timestamp": 1512144000,
+                        "notes": "必须打卡的日期",
+                        "checkintime": [
+                            {
+                                "work_sec": 32400,
+                                "off_work_sec": 61200,
+                                "remind_work_sec": 31800,
+                                "remind_off_work_sec": 61200
+                            }
+                        ]
+                    }
+                ],
+                "spe_offdays": [
+                    {
+                        "timestamp": 1512057600,
+                        "notes": "不需要打卡的日期",
+                        "checkintime": []
+                    }
+                ],
+                "sync_holidays": true,
+                "groupname": "打卡规则1",
+                "need_photo": true,
+                "wifimac_infos": [
+                    {
+                        "wifiname": "Tencent-WiFi-1",
+                        "wifimac": "c0:7b:bc:37:f8:d3"
+                    },
+                    {
+                        "wifiname": "Tencent-WiFi-2",
+                        "wifimac": "70:10:5c:7d:f6:d5"
+                    }
+                ],
+                "note_can_use_local_pic": false,
+                "allow_checkin_offworkday": true,
+                "allow_apply_offworkday": true,
+                "loc_infos": [
+                    {
+                        "lat": 30547030,
+                        "lng": 104062890,
+                        "loc_title": "腾讯成都大厦",
+                        "loc_detail": "四川省成都市武侯区高新南区天府三街",
+                        "distance": 300
+                    },
+                    {
+                        "lat": 23097490,
+                        "lng": 113323750,
+                        "loc_title": "T.I.T创意园",
+                        "loc_detail": "广东省广州市海珠区新港中路397号",
+                        "distance": 300
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/fixtures/work/corp_getopenapprovaldata.json
+++ b/tests/fixtures/work/corp_getopenapprovaldata.json
@@ -1,0 +1,48 @@
+{
+    "errcode": 0,
+    "errmsg": "ok",
+    "data": {
+        "ThirdNo": "201806010001",
+        "OpenTemplateId": "1234567111",
+        "OpenSpName": "付款",
+        "OpenSpstatus": 1,
+        "ApplyTime": 1527837645,
+        "ApplyUsername": "jackiejjwu",
+        "ApplyUserParty": "产品部",
+        "ApplyUserImage": "http://www.qq.com/xxx.png",
+        "ApplyUserId": "WuJunJie",
+        "ApprovalNodes": {
+            "ApprovalNode": [
+                {
+                    "NodeStatus": 1,
+                    "NodeAttr": 1,
+                    "NodeType": 1,
+                    "Items": {
+                        "Item": [
+                            {
+                                "ItemName": "chauvetxiao",
+                                "ItemParty": "产品部",
+                                "ItemImage": "http://www.qq.com/xxx.png",
+                                "ItemUserId": "XiaoWen",
+                                "ItemStatus": 1,
+                                "ItemSpeech": "",
+                                "ItemOpTime": 0
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "NotifyNodes": {
+            "NotifyNode": [
+                {
+                    "ItemName": "jinhuiguo",
+                    "ItemParty": "行政部",
+                    "ItemImage": "http://www.qq.com/xxx.png",
+                    "ItemUserId": "GuoJinHui"
+                }
+            ]
+        },
+        "approverstep": 0
+    }
+}

--- a/tests/fixtures/work/dial_get_dial_record.json
+++ b/tests/fixtures/work/dial_get_dial_record.json
@@ -1,0 +1,42 @@
+{
+   "errcode": 0,
+   "errmsg": "ok",
+   "record":[
+           {
+            "call_time":1536508800,
+            "total_duration":10,
+            "call_type":1,
+            "caller":
+            {
+                "userid":"tony",
+                "duration":10
+            },
+            "callee":[
+            {
+                "phone":138000800,
+                "duration":10
+            }
+            ]
+        },
+        {
+            "call_time":1536940800,
+            "total_duration":20,
+            "call_type":2,
+            "caller":
+            {
+                "userid":"tony",
+                "duration":10
+            },
+            "callee":[
+                {
+                    "phone":138000800,
+                    "duration":5
+                },
+                {
+                    "userid":"tom",
+                    "duration":5
+                }
+            ]
+        }
+   ]
+}

--- a/tests/test_work_client.py
+++ b/tests/test_work_client.py
@@ -307,3 +307,33 @@ class WeChatClientTestCase(unittest.TestCase):
         with HTTMock(wechat_api_mock):
             res = self.client.external_contact.transfer("woAJ2GCAAAXtWyujaWJHDDGi0mACH71w", "zhangsan", "lisi")
             self.assertEqual(0, res["errcode"])
+
+    def test_oa_get_checkin_data(self):
+        with HTTMock(wechat_api_mock):
+            res = self.client.oa.get_checkin_data(
+                data_type=3, start_time=1492617600, end_time=1492790400, userid_list=["james", "paul"]
+            )
+            self.assertIsInstance(res, dict, msg="the returned result should be dict type")
+            self.assertEqual(0, res["errcode"])
+
+    def test_oa_get_checkin_data_with_invalid_datatype(self):
+        with HTTMock(wechat_api_mock):
+            self.assertRaises(
+                ValueError,
+                self.client.oa.get_checkin_data,
+                data_type=5,
+                start_time=1492617600,
+                end_time=1492790400,
+                userid_list=["james", "paul"],
+            )
+
+    def test_oa_get_checkin_data_with_invalid_timestamp(self):
+        with HTTMock(wechat_api_mock):
+            self.assertRaises(
+                ValueError,
+                self.client.oa.get_checkin_data,
+                data_type=5,
+                start_time=1492790400,
+                end_time=1492617600,
+                userid_list=["james", "paul"],
+            )

--- a/tests/test_work_client.py
+++ b/tests/test_work_client.py
@@ -337,3 +337,9 @@ class WeChatClientTestCase(unittest.TestCase):
                 end_time=1492617600,
                 userid_list=["james", "paul"],
             )
+
+    def test_oa_get_checkin_option(self):
+        with HTTMock(wechat_api_mock):
+            res = self.client.oa.get_checkin_option(datetime=1511971200, userid_list=["james", "paul"])
+            self.assertIsInstance(res, dict, msg="the returned result should be dict type")
+            self.assertEqual(0, res["errcode"])

--- a/tests/test_work_client.py
+++ b/tests/test_work_client.py
@@ -257,7 +257,7 @@ class WeChatClientTestCase(unittest.TestCase):
         with HTTMock(wechat_api_mock):
             res = self.client.external_contact.add_msg_template(
                 {
-                    "external_userid": ["woAJ2GCAAAXtWyujaWJHDDGi0mACas1w", "wmqfasd1e1927831291723123109r712",],
+                    "external_userid": ["woAJ2GCAAAXtWyujaWJHDDGi0mACas1w", "wmqfasd1e1927831291723123109r712"],
                     "sender": "zhangsan",
                     "text": {"content": "文本消息内容"},
                     "image": {"media_id": "MEDIA_ID"},

--- a/tests/test_work_client.py
+++ b/tests/test_work_client.py
@@ -308,6 +308,23 @@ class WeChatClientTestCase(unittest.TestCase):
             res = self.client.external_contact.transfer("woAJ2GCAAAXtWyujaWJHDDGi0mACH71w", "zhangsan", "lisi")
             self.assertEqual(0, res["errcode"])
 
+    def test_oa_get_dial_record(self):
+        with HTTMock(wechat_api_mock):
+            res = self.client.oa.get_dial_record(start_time=1536508800, end_time=1536940800, offset=0, limit=100)
+            self.assertIsInstance(res, dict, msg="the returned result should be dict type")
+            self.assertEqual(0, res["errcode"])
+
+    def test_os_get_dial_record_with_invalid_timestamp(self):
+        with HTTMock(wechat_api_mock):
+            self.assertRaises(
+                ValueError,
+                self.client.oa.get_dial_record,
+                start_time=1536940800,
+                end_time=1536508800,
+                offset=0,
+                limit=100,
+            )
+
     def test_oa_get_checkin_data(self):
         with HTTMock(wechat_api_mock):
             res = self.client.oa.get_checkin_data(

--- a/tests/test_work_client.py
+++ b/tests/test_work_client.py
@@ -360,3 +360,9 @@ class WeChatClientTestCase(unittest.TestCase):
             res = self.client.oa.get_checkin_option(datetime=1511971200, userid_list=["james", "paul"])
             self.assertIsInstance(res, dict, msg="the returned result should be dict type")
             self.assertEqual(0, res["errcode"])
+
+    def test_oa_get_open_approval_data(self):
+        with HTTMock(wechat_api_mock):
+            res = self.client.oa.get_open_approval_data(third_no="201806010001")
+            self.assertIsInstance(res, dict, msg="the returned result should be dict type")
+            self.assertEqual(0, res["errcode"])

--- a/wechatpy/work/client/api/oa.py
+++ b/wechatpy/work/client/api/oa.py
@@ -127,3 +127,21 @@ class WeChatOA(BaseWeChatAPI):
             "useridlist": userid_list,
         }
         return self._post("checkin/getcheckindata", data=data)
+
+    def get_checkin_option(self, datetime: int, userid_list: List[str]) -> Union[dict, requests.models.Response]:
+        """
+        获取打卡规则
+        https://work.weixin.qq.com/api/doc/90000/90135/90263
+
+        - 用户列表不超过100个，若用户超过100个，请分批获取。
+        - 用户在不同日期的规则不一定相同，请按天获取。
+
+        :param datetime: 需要获取规则的日期当天0点的Unix时间戳
+        :param userid_list: 需要获取打卡规则的用户列表
+        :return: 打卡规则
+        """
+        if not userid_list:
+            raise ValueError("the userid_list can't be an empty list")
+
+        data = {"datetime": datetime, "useridlist": userid_list}
+        return self._post("checkin/getcheckinoption", data=data)

--- a/wechatpy/work/client/api/oa.py
+++ b/wechatpy/work/client/api/oa.py
@@ -38,7 +38,7 @@ class WeChatOA(BaseWeChatAPI):
         :return:
         """
         data = optionaldict(
-            {"starttime": str(start_time), "endtime": str(end_time), "cursor": cursor, "size": size, "filter": filters,}
+            {"starttime": str(start_time), "endtime": str(end_time), "cursor": cursor, "size": size, "filter": filters}
         )
 
         return self._post("oa/getapprovalinfo", data=data)

--- a/wechatpy/work/client/api/oa.py
+++ b/wechatpy/work/client/api/oa.py
@@ -3,8 +3,7 @@
 
 from optionaldict import optionaldict
 from wechatpy.client.api.base import BaseWeChatAPI
-from typing import Union, List, Optional
-import requests.models
+from typing import List, Optional
 
 
 class WeChatOA(BaseWeChatAPI):
@@ -95,7 +94,7 @@ class WeChatOA(BaseWeChatAPI):
 
     def get_dial_record(
         self, start_time: Optional[int] = None, end_time: Optional[int] = None, offset: int = 0, limit: int = 100
-    ) -> Union[dict, requests.models.Response]:
+    ) -> dict:
         """
         获取公费电话拨打记录
         https://work.weixin.qq.com/api/doc/90000/90135/90267
@@ -123,9 +122,7 @@ class WeChatOA(BaseWeChatAPI):
         data = {"start_time": start_time, "end_time": end_time, "offset": offset, "limit": limit}
         return self._post("dial/get_dial_record", data=data)
 
-    def get_checkin_data(
-        self, data_type: int, start_time: int, end_time: int, userid_list: List[str]
-    ) -> Union[dict, requests.models.Response]:
+    def get_checkin_data(self, data_type: int, start_time: int, end_time: int, userid_list: List[str]) -> dict:
         """
         获取打卡数据
         https://work.weixin.qq.com/api/doc/90000/90135/90262
@@ -158,7 +155,7 @@ class WeChatOA(BaseWeChatAPI):
         }
         return self._post("checkin/getcheckindata", data=data)
 
-    def get_checkin_option(self, datetime: int, userid_list: List[str]) -> Union[dict, requests.models.Response]:
+    def get_checkin_option(self, datetime: int, userid_list: List[str]) -> dict:
         """
         获取打卡规则
         https://work.weixin.qq.com/api/doc/90000/90135/90263
@@ -176,7 +173,7 @@ class WeChatOA(BaseWeChatAPI):
         data = {"datetime": datetime, "useridlist": userid_list}
         return self._post("checkin/getcheckinoption", data=data)
 
-    def get_open_approval_data(self, third_no: str) -> Union[dict, requests.models.Response]:
+    def get_open_approval_data(self, third_no: str) -> dict:
         """
         查询自建应用审批单当前状态
         https://work.weixin.qq.com/api/doc/90000/90135/90269

--- a/wechatpy/work/client/api/oa.py
+++ b/wechatpy/work/client/api/oa.py
@@ -175,3 +175,14 @@ class WeChatOA(BaseWeChatAPI):
 
         data = {"datetime": datetime, "useridlist": userid_list}
         return self._post("checkin/getcheckinoption", data=data)
+
+    def get_open_approval_data(self, third_no: str) -> Union[dict, requests.models.Response]:
+        """
+        查询自建应用审批单当前状态
+        https://work.weixin.qq.com/api/doc/90000/90135/90269
+
+        :param third_no: 开发者发起申请时定义的审批单号
+        :return: 审批单的当前审批状态
+        """
+        data = {"thirdNo": third_no}
+        return self._post("corp/getopenapprovaldata", data=data)

--- a/wechatpy/work/client/api/oa.py
+++ b/wechatpy/work/client/api/oa.py
@@ -3,7 +3,7 @@
 
 from optionaldict import optionaldict
 from wechatpy.client.api.base import BaseWeChatAPI
-from typing import Union, List
+from typing import Union, List, Optional
 import requests.models
 
 
@@ -92,6 +92,36 @@ class WeChatOA(BaseWeChatAPI):
             }
         )
         return self._post("oa/applyevent", data=data)
+
+    def get_dial_record(
+        self, start_time: Optional[int] = None, end_time: Optional[int] = None, offset: int = 0, limit: int = 100
+    ) -> Union[dict, requests.models.Response]:
+        """
+        获取公费电话拨打记录
+        https://work.weixin.qq.com/api/doc/90000/90135/90267
+
+        企业可通过此接口，按时间范围拉取成功接通的公费电话拨打记录。
+
+        请注意，查询的时间范围为[start_time,end_time]，即前后均为闭区间。在两个参数都
+        指定了的情况下，结束时间不得小于开始时间，开始时间也不得早于当前时间，否则会返回
+        600018错误码(无效的起止时间)。
+
+        受限于网络传输，起止时间的最大跨度为30天，如超过30天，则以结束时间为基准向前取
+        30天进行查询。
+
+        如果未指定起止时间，则默认查询最近30天范围内数据。
+
+        :param start_time: 查询的起始时间戳
+        :param end_time: 查询的结束时间戳
+        :param offset: 分页查询的偏移量
+        :param limit: 分页查询的每页大小,默认为100条，如该参数大于100则按100处理
+        :return: 公费电话拨打记录
+        """
+        if start_time and end_time and end_time <= start_time:
+            raise ValueError("the end time must be greater than the begining time")
+
+        data = {"start_time": start_time, "end_time": end_time, "offset": offset, "limit": limit}
+        return self._post("dial/get_dial_record", data=data)
 
     def get_checkin_data(
         self, data_type: int, start_time: int, end_time: int, userid_list: List[str]


### PR DESCRIPTION
添加接口如下：
- 获取公费电话拨打记录
- 获取打卡数据
- 获取打卡规则
- 查询自建应用审批单当前状态

定义的函数返回类型为`Union[dict, requests.models.Response]`，`wechatpy/client/base.py:83`的返回值在解码失败后，返回的是`Response`对象，故这里使用了联合类型。