### PR TITLE
fix: 小程序云开发无法上传较大文件

### DIFF
--- a/wechatpy/client/api/cloud.py
+++ b/wechatpy/client/api/cloud.py
@@ -263,6 +263,7 @@ class WeChatCloud(BaseWeChatAPI):
                     "Signature": signature,
                     "x-cos-security-token": token,
                     "x-cos-meta-fileid": cos_file_id,
+                    # 注意！file 字段须放在最后，否则上传大文件会失败
                     "file": f,
                 },
             )

--- a/wechatpy/client/api/cloud.py
+++ b/wechatpy/client/api/cloud.py
@@ -259,11 +259,11 @@ class WeChatCloud(BaseWeChatAPI):
             upload_res = requests.post(
                 res["url"],
                 files={
-                    "file": f,
                     "key": path,
                     "Signature": signature,
                     "x-cos-security-token": token,
                     "x-cos-meta-fileid": cos_file_id,
+                    "file": f,
                 },
             )
             upload_res.raise_for_status()


### PR DESCRIPTION
fix: 小程序云开发无法上传大文件

在小程序云开发的 uploadFile 上传链接使用的时候，需要拼装一个 HTTP POST 请求，如果将 file 字段放在第一个字段，并且文件内容较大的情况下，请求会返回 400，如果放在最后一个字段就能够成功返回 204

### 在 HTTP 客户端中模拟上传文件

获取到 uploadFile API 返回的 JSON 数据之后，然后模拟一个 form-data 请求（文件大小为 `12.3 MB`）

#### file 放在第一个字段，返回 400

![image](https://user-images.githubusercontent.com/1612364/81392837-d8914900-9151-11ea-8a86-8bdb2c6b2c5a.png)

#### file 字段放在最后，返回 204

![image](https://user-images.githubusercontent.com/1612364/81393318-c06df980-9152-11ea-923d-971a051954b1.png)

