### PR TITLE
添加企业微信成员管理的新接口 (#607)

### DIFF
--- a/tests/fixtures/work/corp_get_join_qrcode.json
+++ b/tests/fixtures/work/corp_get_join_qrcode.json
@@ -1,0 +1,5 @@
+{
+   "errcode": 0,
+   "errmsg": "ok",
+   "join_qrcode": "https://work.weixin.qq.com/wework_admin/genqrcode?action=join&vcode=3db1fab03118ae2aa1544cb9abe84&r=hb_share_api_mjoin&qr_size=3"
+}

--- a/tests/fixtures/work/user_get_active_stat.json
+++ b/tests/fixtures/work/user_get_active_stat.json
@@ -1,0 +1,5 @@
+{
+   "errcode": 0,
+   "errmsg": "ok",
+   "active_cnt": 100
+}

--- a/tests/test_work_client.py
+++ b/tests/test_work_client.py
@@ -225,7 +225,7 @@ class WeChatClientTestCase(unittest.TestCase):
 
     def test_user_join_qrcode(self):
         with HTTMock(wechat_api_mock):
-            qrcode_url = self.client.user.join_qrcode()
+            qrcode_url = self.client.user.get_join_qrcode()
             self.assertIsNotNone(qrcode_url)
 
     def test_upload_media(self):

--- a/tests/test_work_client.py
+++ b/tests/test_work_client.py
@@ -218,6 +218,16 @@ class WeChatClientTestCase(unittest.TestCase):
             user_id = self.client.user.convert_to_user_id("oDOGms-6yCnGrRovBj2yHij5JL6E")
             self.assertEqual("zhangsan", user_id)
 
+    def test_user_get_active_stat(self):
+        with HTTMock(wechat_api_mock):
+            active_stat = self.client.user.get_active_stat("2020-03-27")
+            self.assertEqual(active_stat, 100)
+
+    def test_user_join_qrcode(self):
+        with HTTMock(wechat_api_mock):
+            qrcode_url = self.client.user.join_qrcode()
+            self.assertIsNotNone(qrcode_url)
+
     def test_upload_media(self):
         media_file = io.StringIO("nothing")
         with HTTMock(wechat_api_mock):

--- a/wechatpy/work/client/api/user.py
+++ b/wechatpy/work/client/api/user.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from typing import Optional
 
 from optionaldict import optionaldict
 
@@ -120,7 +121,12 @@ class WeChatUser(BaseWeChatAPI):
         """
         url = "user/simplelist" if simple else "user/list"
         res = self._get(
-            url, params={"department_id": department_id, "fetch_child": 1 if fetch_child else 0, "status": status,},
+            url,
+            params={
+                "department_id": department_id,
+                "fetch_child": 1 if fetch_child else 0,
+                "status": status,
+            },
         )
         return res["userlist"]
 
@@ -161,3 +167,27 @@ class WeChatUser(BaseWeChatAPI):
 
     def get_info(self, agent_id, code):
         return self._get("user/getuserinfo", params={"agentid": agent_id, "code": code})
+
+    def join_qrcode(self, size_type: Optional[int] = None) -> str:
+        """
+        获取加入企业二维码
+
+        该接口用于获取企业用户实时成员加入的二维码。详细接口细节请查看 `接口文档`_。
+
+        需要注意的是获取到的二维码链接，**有效期为7天**。
+
+        :param size_type: 图片尺寸类型。可用尺寸有：
+            1: 171 x 171;
+            2: 399 x 399;
+            3: 741 x 741（默认）;
+            4: 2052 x 2052
+        :return: 二维码链接
+
+        .. _接口文档: https://work.weixin.qq.com/api/doc/90000/90135/91714
+
+        .. warning:: 使用本接口请确保开启了 **通讯录同步** 的API接口同步，并使用
+          **通讯录同步** 的 ``secret``，否则调用接口时会出现错误。
+        """
+        params = optionaldict(size_type=size_type)
+        resp = self._get("corp/get_join_qrcode", params=params)
+        return resp["join_qrcode"]

--- a/wechatpy/work/client/api/user.py
+++ b/wechatpy/work/client/api/user.py
@@ -191,3 +191,19 @@ class WeChatUser(BaseWeChatAPI):
         params = optionaldict(size_type=size_type)
         resp = self._get("corp/get_join_qrcode", params=params)
         return resp["join_qrcode"]
+
+    def get_active_stat(self, date: str) -> int:
+        """
+        获取企业活跃成员数
+
+        该接口用于获取指定日期的企业的成员活跃数量，详细接口细节请查看 `接口文档`_。
+
+        :param date: 具体某天的活跃人数，最长支持获取30天前数据。格式为: ``YYYY-MM-DD``。
+        :return: 成员活跃数量
+
+        .. _接口文档:: https://work.weixin.qq.com/api/doc/90000/90135/92714
+
+        .. warning:: 仅通讯录同步助手可调用。
+        """
+        resp = self._post("user/get_active_stat", data={"date": date})
+        return resp["active_cnt"]

--- a/wechatpy/work/client/api/user.py
+++ b/wechatpy/work/client/api/user.py
@@ -168,7 +168,7 @@ class WeChatUser(BaseWeChatAPI):
     def get_info(self, agent_id, code):
         return self._get("user/getuserinfo", params={"agentid": agent_id, "code": code})
 
-    def join_qrcode(self, size_type: Optional[int] = None) -> str:
+    def get_join_qrcode(self, size_type: Optional[int] = None) -> str:
         """
         获取加入企业二维码
 


### PR DESCRIPTION
企业微信新增了两个接口：
- [企业微信加入企业二维码](https://work.weixin.qq.com/api/doc/90000/90135/91714)
- [获取企业活跃成员数量](https://work.weixin.qq.com/api/doc/90000/90135/92714)