### PR TITLE
CI.yml: Add Python 3.10 to the testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     services:
       redis:
         image: redis
@@ -23,11 +23,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
+        shell: python
+        run: |
+            import sys
+            print(sys.version)
       - name: Install Dependencies
         run: |
           pip install poetry
@@ -53,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install Dependencies


### PR DESCRIPTION
https://pythoninsider.blogspot.com/2021/10/python-3100-is-available.html

"3.10" ___must___ be quoted in YAML. https://dev.to/hugovk/the-python-3-1-problem-85g

The other way to do `Display Python version` would be `python -VV` (more info) or `python -V` or `python --version` (less info).