### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,9 @@ jobs:
           - 11211:11211
     steps:
       - uses: actions/checkout@v2
+      - uses: codespell-project/actions-codespell@master
+        with:
+          ignore_words_list: ba
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -143,7 +143,7 @@ Released on 2019-03-15
 Version 1.7.6
 -----------------
 
-Relased on 2019-01-04
+Released on 2019-01-04
 
 + 增加获取所有用户 openid API
 + 增加菜单进入小程序事件

--- a/tests/fixtures/work/externalcontact_get.json
+++ b/tests/fixtures/work/externalcontact_get.json
@@ -4,7 +4,7 @@
   "external_contact":{
     "external_userid":"woAJ2GCAAAXtWyujaWJHDDGi0mACH71w",
     "name":"李四",
-    "position":"Mangaer",
+    "position":"Manager",
     "avatar":"http://p.qlogo.cn/bizmail/IcsdgagqefergqerhewSdage/0",
     "corp_name":"腾讯",
     "corp_full_name":"腾讯科技有限公司",

--- a/wechatpy/work/client/api/oa.py
+++ b/wechatpy/work/client/api/oa.py
@@ -117,7 +117,7 @@ class WeChatOA(BaseWeChatAPI):
         :return: 公费电话拨打记录
         """
         if start_time and end_time and end_time <= start_time:
-            raise ValueError("the end time must be greater than the begining time")
+            raise ValueError("the end time must be greater than the beginning time")
 
         data = {"start_time": start_time, "end_time": end_time, "offset": offset, "limit": limit}
         return self._post("dial/get_dial_record", data=data)
@@ -142,7 +142,7 @@ class WeChatOA(BaseWeChatAPI):
             raise ValueError(f"data_type must be in {list(checkin_data_type.keys())}")
 
         if end_time <= start_time:
-            raise ValueError("the end time must be greater than the begining time")
+            raise ValueError("the end time must be greater than the beginning time")
 
         if not userid_list:
             raise ValueError("the userid_list can't be an empty list")


### PR DESCRIPTION
% [`codespell --count --ignore-words-list=ba .`](https://pypi.org/project/codespell/)
```
./tests/fixtures/work/externalcontact_get.json:7: Mangaer ==> Manager, manger
./docs/changelog.rst:146: Relased ==> Released
./wechatpy/work/client/api/oa.py:120: begining ==> beginning
./wechatpy/work/client/api/oa.py:145: begining ==> beginning
4
```