### PR TITLE
Delete unused Hound CI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-flake8:
-  enabled: true
-  config_file: setup.cfg

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,3 @@
 flake8:
   enabled: true
   config_file: setup.cfg
-
-fail_on_violations: true


### PR DESCRIPTION
It is easier to run flake8 in a GitHub Action so we should probably abandon the hound.