### PR TITLE
fix: Inconsistent 'expires_at' on 'BaseWeChatClient' (#684)

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 import inspect
+import time
 import unittest
 from datetime import datetime
 
@@ -830,3 +831,16 @@ class WeChatClientTestCase(unittest.TestCase):
         self.assertEqual("D1ZWEygStjuLCnZ9IN2l4Q==", res["session_key"])
         self.assertEqual("o16wA0b4AZKzgVJR3MBwoUdTfU_E", res["openid"])
         self.assertEqual("or4zX05h_Ykt4ju0TUfx3CQsvfTo", res["unionid"])
+
+    def test_client_expires_at_consistency(self):
+        from redis import Redis
+        from wechatpy.session.redisstorage import RedisStorage
+
+        redis = Redis()
+        session = RedisStorage(redis)
+        client1 = WeChatClient(self.app_id, self.secret, session=session)
+        client2 = WeChatClient(self.app_id, self.secret, session=session)
+        assert client1.expires_at == client2.expires_at
+        expires_at = time.time() + 7200
+        client1.expires_at = expires_at
+        assert client1.expires_at == client2.expires_at == expires_at

--- a/wechatpy/client/base.py
+++ b/wechatpy/client/base.py
@@ -34,7 +34,6 @@ class BaseWeChatClient:
     def __init__(self, appid, access_token=None, session=None, timeout=None, auto_retry=True):
         self._http = requests.Session()
         self.appid = appid
-        self.expires_at = None
         self.session = session or MemoryStorage()
         self.timeout = timeout
         self.auto_retry = auto_retry
@@ -45,6 +44,18 @@ class BaseWeChatClient:
     @property
     def access_token_key(self):
         return f"{self.appid}_access_token"
+
+    @property
+    def access_token_expires_at_key(self):
+        return f"{self.appid}_access_token_expires_at"
+
+    @property
+    def expires_at(self):
+        return self.session.get(self.access_token_expires_at_key, None)
+
+    @expires_at.setter
+    def expires_at(self, value):
+        self.session.set(self.access_token_expires_at_key, value)
 
     def _request(self, method, url_or_endpoint, **kwargs):
         if not url_or_endpoint.startswith(("http://", "https://")):


### PR DESCRIPTION
使用session来存储`expires_at`来防止多实例情况下可能出现的`expires_at`不一致导致的重复刷新`access_token`的问题，见 Closes https://github.com/wechatpy/wechatpy/issues/684