### PR TITLE
fix field name "filters" in get_approval_info

### DIFF
--- a/wechatpy/work/client/api/oa.py
+++ b/wechatpy/work/client/api/oa.py
@@ -37,7 +37,7 @@ class WeChatOA(BaseWeChatAPI):
         :return:
         """
         data = optionaldict(
-            {"starttime": str(start_time), "endtime": str(end_time), "cursor": cursor, "size": size, "filter": filters}
+            {"starttime": str(start_time), "endtime": str(end_time), "cursor": cursor, "size": size, "filters": filters}
         )
 
         return self._post("oa/getapprovalinfo", data=data)


### PR DESCRIPTION
According to the description in the document at https://developer.work.weixin.qq.com/document/path/91816, the correct field name should be "filters". Previously version, it was incorrectly written as "filter", which caused the filters not working.